### PR TITLE
Implement slicing functionality

### DIFF
--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -1,15 +1,7 @@
 using Tensors: Tensor
-using Memoize
 
 flops(::Tensor) = 0
-@memoize function flops(expr::EinExpr)
-    flops_sub = sum(flops.(expr.args))
-
-    floppi(inds) = mapreduce(i -> size(expr, i), *, inds, init = one(BigInt))
-    flops_cur = floppi(suminds(expr)) * (isempty(suminds(expr)) && length(expr.args) == 1 ? 0 : floppi(labels(expr)))
-
-    return flops_sub + flops_cur
-end
+flops(expr::EinExpr) = mapreduce(i -> size(expr, i), *, [labels(expr)..., suminds(expr)...])
 
 removedsize(::Tensor) = 0
 removedsize(expr::EinExpr) = mapreduce(prod ∘ size, +, expr.args) - prod(size(expr))

--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -1,7 +1,12 @@
 using Tensors: Tensor
 
 flops(::Tensor) = 0
-flops(expr::EinExpr) = mapreduce(i -> size(expr, i), *, [labels(expr)..., suminds(expr)...])
+flops(expr::EinExpr) =
+    if isempty(suminds(expr)) && length(expr.args) == 1
+        0
+    else
+        mapreduce(i -> size(expr, i), *, [labels(expr)..., suminds(expr)...])
+    end
 
 removedsize(::Tensor) = 0
 removedsize(expr::EinExpr) = mapreduce(prod ∘ size, +, expr.args) - prod(size(expr))

--- a/src/EinExpr.jl
+++ b/src/EinExpr.jl
@@ -40,12 +40,7 @@ Return the size of the `Tensor` resulting from contracting `expr`. If `index` is
 """
 Base.size(expr::EinExpr) = tuple((size(expr, i) for i in labels(expr))...)
 
-function Base.size(expr::EinExpr, i::Symbol)
-    target = findfirst(input -> i ∈ labels(input), expr.args)
-    isnothing(target) && throw(KeyError(i))
-
-    return size(expr.args[target], i)
-end
+Base.size(expr::EinExpr, i::Symbol) = Iterators.filter(∋(i) ∘ labels, expr) |> first |> x -> size(x, i)
 
 """
     select(expr, i)

--- a/src/EinExprs.jl
+++ b/src/EinExprs.jl
@@ -8,6 +8,7 @@ include("Counters.jl")
 export flops, removedsize
 
 include("Slicing.jl")
+export slices
 
 include("Optimizers/Optimizers.jl")
 export Optimizer, einexpr

--- a/src/EinExprs.jl
+++ b/src/EinExprs.jl
@@ -8,7 +8,7 @@ include("Counters.jl")
 export flops, removedsize
 
 include("Slicing.jl")
-export slices
+export findslices, FlopsScorer, SizeScorer
 
 include("Optimizers/Optimizers.jl")
 export Optimizer, einexpr

--- a/src/EinExprs.jl
+++ b/src/EinExprs.jl
@@ -7,6 +7,8 @@ export suminds, path, select
 include("Counters.jl")
 export flops, removedsize
 
+include("Slicing.jl")
+
 include("Optimizers/Optimizers.jl")
 export Optimizer, einexpr
 export Exhaustive, Greedy

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -17,7 +17,7 @@ Exhaustive contraction path optimizers. It guarantees to find the optimal contra
 The algorithm has a ``\mathcal{O}(n!)`` time complexity if `outer = true` and ``\mathcal{O}(\exp(n))`` if `outer = false`.
 """
 @kwdef struct Exhaustive <: Optimizer
-    metric::Function = flops
+    metric::Function = path -> mapreduce(flops, +, path)
     outer::Bool = false
 end
 

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -15,7 +15,7 @@ Base.view(path::EinExpr, cuttings::Pair{Symbol,<:Integer}...) =
     end
 
 function slices(
-    target::Function,
+    target,
     path::EinExpr;
     size = nothing,
     overhead = nothing,

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -23,6 +23,7 @@ function slices(
     candidates = setdiff(labels(path, all=true), skip)
     solution = Set{Symbol}()
     current = (; slices=1, size=maximum(size, path), overhead=1.0)
+    original_flops = flops(path)
 
     sliced_path = path
     while !(!isnothing(slices) && current.slices >= slices || !isnothing(size) && current.size <= size)
@@ -35,7 +36,7 @@ function slices(
         current = (;
             slices=current.slices * size(path, winner),
             size=maximum(size, sliced_path),
-            overhead=flops(sliced_path) / flops(path)
+            overhead=flops(sliced_path) / original_flops
         )
 
         !isnothing(overhead) && current.overhead > overhead && break

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -1,0 +1,12 @@
+Base.selectdim(path::EinExpr, index::Symbol, i) = EinExpr(map(path.args) do sub
+        index ∈ __labels_children(sub) ? selectdim(sub, index, i) : sub
+    end, filter(!=(index), path.head))
+
+__labels_children(x) = labels(x)
+__labels_children(path::EinExpr) = labels(path, all=true)
+
+Base.view(path::EinExpr, cuttings::Pair{Symbol,<:Integer}...) =
+    reduce(cuttings, init=path) do acc, proj
+        d, i = proj
+        selectdim(acc, d, i)
+    end

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -1,12 +1,15 @@
-Base.selectdim(path::EinExpr, index::Symbol, i) = EinExpr(map(path.args) do sub
+Base.selectdim(path::EinExpr, index::Symbol, i) = EinExpr(
+    map(path.args) do sub
         index ∈ __labels_children(sub) ? selectdim(sub, index, i) : sub
-    end, filter(!=(index), path.head))
+    end,
+    filter(!=(index), path.head),
+)
 
 __labels_children(x) = labels(x)
-__labels_children(path::EinExpr) = labels(path, all=true)
+__labels_children(path::EinExpr) = labels(path, all = true)
 
 Base.view(path::EinExpr, cuttings::Pair{Symbol,<:Integer}...) =
-    reduce(cuttings, init=path) do acc, proj
+    reduce(cuttings, init = path) do acc, proj
         d, i = proj
         selectdim(acc, d, i)
     end
@@ -14,19 +17,22 @@ Base.view(path::EinExpr, cuttings::Pair{Symbol,<:Integer}...) =
 function slices(
     target::Function,
     path::EinExpr;
-    size=nothing,
-    overhead=nothing,
-    slices=nothing,
-    temperature=0.01,
-    skip=Set{Symbol}()
+    size = nothing,
+    overhead = nothing,
+    slices = nothing,
+    temperature = 0.01,
+    skip = Set{Symbol}(),
 )
-    candidates = setdiff(labels(path, all=true), skip)
+    candidates = setdiff(labels(path, all = true), skip)
     solution = Set{Symbol}()
-    current = (; slices=1, size=maximum(size, path), overhead=1.0)
+    current = (; slices = 1, size = maximum(size, path), overhead = 1.0)
     original_flops = flops(path)
 
     sliced_path = path
-    while !(!isnothing(slices) && current.slices >= slices || !isnothing(size) && current.size <= size)
+    while !(
+        !isnothing(slices) && current.slices >= slices ||
+        !isnothing(size) && current.size <= size
+    )
         # temperature adds boltzmann like noise
         winner = maximum(candidates) do index
             target(sliced_path, index) - temperature * (log ∘ (-) ∘ log ∘ rand)()
@@ -34,9 +40,9 @@ function slices(
 
         sliced_path = selectdim(sliced_path, winner, 1)
         current = (;
-            slices=current.slices * size(path, winner),
-            size=maximum(size, sliced_path),
-            overhead=flops(sliced_path) / original_flops
+            slices = current.slices * size(path, winner),
+            size = maximum(size, sliced_path),
+            overhead = flops(sliced_path) / original_flops,
         )
 
         !isnothing(overhead) && current.overhead > overhead && break

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -11,7 +11,7 @@ Base.view(path::EinExpr, cuttings::Pair{Symbol,<:Integer}...) =
         selectdim(acc, d, i)
     end
 
-function slices(
+function findslices(
     scorer,
     path::EinExpr;
     size = nothing,

--- a/test/Exhaustive_test.jl
+++ b/test/Exhaustive_test.jl
@@ -35,7 +35,7 @@
     expr = einexpr(Exhaustive, EinExpr(tensors, [:p, :j]))
     @test expr isa EinExpr
     # TODO traverse through the tree and check everything is ok
-    @test flops(expr) == 48753
+    @test mapreduce(flops, +, expr) == 48753
     # FIXME non-determinist behaviour on order
     @test issetequal(path(expr), [[:q], [:m], [:f, :i], [:g, :l], [:b], [:o], [:c, :e], [:n, :a, :d, :h], [:k]])
 end

--- a/test/Slicing_test.jl
+++ b/test/Slicing_test.jl
@@ -1,0 +1,90 @@
+@testset "Slicing" begin
+    sizes = Dict(
+        :o => 3,
+        :b => 7,
+        :p => 6,
+        :n => 7,
+        :j => 9,
+        :k => 8,
+        :d => 4,
+        :e => 2,
+        :c => 2,
+        :h => 5,
+        :i => 5,
+        :l => 10,
+        :m => 7,
+        :q => 5,
+        :a => 3,
+        :f => 7,
+        :g => 3,
+    )
+
+    expr = EinExpr(
+        [
+            EinExpr(
+                [
+                    EinExpr(
+                        [
+                            EinExpr(
+                                [
+                                    EinExpr(
+                                        [
+                                            EinExpr(
+                                                [
+                                                    EinExpr(
+                                                        [
+                                                            EinExpr(
+                                                                [
+                                                                    Tensor(
+                                                                        ones((sizes[i] for i in [:m, :f, :q])...),
+                                                                        [:m, :f, :q],
+                                                                    ),
+                                                                    Tensor(
+                                                                        ones((sizes[i] for i in [:g, :q])...),
+                                                                        [:g, :q],
+                                                                    ),
+                                                                ],
+                                                                [:m, :f, :g],
+                                                            ),
+                                                            Tensor(
+                                                                ones((sizes[i] for i in [:o, :i, :m, :c])...),
+                                                                [:o, :i, :m, :c],
+                                                            ),
+                                                        ],
+                                                        [:f, :g, :o, :i, :c],
+                                                    ),
+                                                    Tensor(ones((sizes[i] for i in [:f, :l, :i])...), [:f, :l, :i]),
+                                                ],
+                                                [:g, :o, :c, :l],
+                                            ),
+                                            Tensor(ones((sizes[i] for i in [:g, :n, :l, :a])...), [:g, :n, :l, :a]),
+                                        ],
+                                        [:o, :c, :n, :a],
+                                    ),
+                                    EinExpr(
+                                        [
+                                            Tensor(ones((sizes[i] for i in [:b, :e])...), [:b, :e]),
+                                            Tensor(ones((sizes[i] for i in [:d, :b, :o])...), [:d, :b, :o]),
+                                        ],
+                                        [:e, :d, :o],
+                                    ),
+                                ],
+                                [:c, :n, :a, :e, :d],
+                            ),
+                            Tensor(ones((sizes[i] for i in [:c, :e, :h])...), [:c, :e, :h]),
+                        ],
+                        [:n, :a, :d, :h],
+                    ),
+                    Tensor(ones((sizes[i] for i in [:k, :d, :h, :a, :n, :j])...), [:k, :d, :h, :a, :n, :j]),
+                ],
+                [:k, :j],
+            ),
+            Tensor(ones((sizes[i] for i in [:p, :k])...), [:p, :k]),
+        ],
+        [:p, :j],
+    )
+
+    cuttings = findslices(FlopsScorer(), expr, slices = 1000)
+
+    @test prod(i -> size(expr, i), cuttings) >= 1000
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using EinExprs
     @testset "Optimizers" verbose = true begin
         include("Exhaustive_test.jl")
     end
+    include("Slicing_test.jl")
 end
 
 @testset "Integration tests" verbose = true begin


### PR DESCRIPTION
This PR closes #19. It adds slicing functionality to `EinExpr`s. Specifically,
- [x] Specializes `selectdim` and `view` methods for manually slicing `EinExpr`s (i.e. contraction paths).
- [x] Adds the `slices` method for automatic slice search based on `contengra`'s `SliceFinder` algorithm.
- [x] Provides some target functions for the `slices` method (user may want to minimize `flops` or `size` or other things).

What is cool about this implementation is that it's significantly shorter than `cotengra`'s code but provides the same functionality. Furthermore, users can program target methods for the `slices` function using the `do` syntax:

```julia
slices(path) do sliced_path, index
    ...
end
```

@jofrevalles Maybe `slices` is not a good name. Do you suggest another name? What do you think of `findslices`?