### PR TITLE
Fix performance regression in `Greedy`

### DIFF
--- a/test/Greedy_test.jl
+++ b/test/Greedy_test.jl
@@ -15,7 +15,7 @@
 
     @test mapreduce(flops, +, Branches(path)) == 100
 
-    @test all(splat(issetequal), zip(contractorder(path), [[:i, :h], [:j], [:a, :e], [:g, :c], [:d], [:b, :f]]))
+    @test all(splat(issetequal), zip(contractorder(path), [[:i, :h], [:j], [:a, :e], [:g, :c], [:f], [:b, :d]]))
 
     @testset "example: let unchanged" begin
         tensors = [


### PR DESCRIPTION
`Greedy` optimizer is wrongly considering outer product between all combinations of tensors as candidates. This in turn translates into an exponential time (and exponential space due to the implementation) execution.

This patch fixes the problem by avoiding outer products by default.

### Before

```julia
# run 1
52.448305 seconds (130.85 M allocations: 62.620 GiB, 15.20% gc time, 1.61% compilation time)
# run 2
42.701409 seconds (129.02 M allocations: 62.499 GiB, 22.22% gc time)
```

![pre](https://github.com/bsc-quantic/EinExprs.jl/assets/15837247/56aab596-80a9-41c2-9245-c49a3c52b985)

### After

```julia
# run 1
2.786559 seconds (9.91 M allocations: 3.123 GiB, 14.70% gc time, 33.00% compilation time)
# run 2
1.843659 seconds (8.20 M allocations: 3.010 GiB, 19.13% gc time)
```

![post](https://github.com/bsc-quantic/EinExprs.jl/assets/15837247/720f3909-b1c1-447a-8b48-9e666f0bba40)
