### PR TITLE
Enhance edge and vertex weights for `HyPar` optimizer

### DIFF
--- a/src/Optimizers/KaHyPar.jl
+++ b/src/Optimizers/KaHyPar.jl
@@ -7,8 +7,8 @@ using KaHyPar
     imbalance::Float32 = 0.03
     stop::Function = <=(2) ∘ length ∘ Base.Fix1(getfield, :args)
     configuration::Union{Nothing,Symbol,String} = nothing
-    edge_weight_scaling::Function = (ind_size) -> 1000 * Int(round(log2(ind_size)))
-    vertex_weight_scaling::Function = (prod_size) -> 1000 * Int(round(log2(prod_size)))
+    edge_scaler::Function = (ind_size) -> 1000 * (Int ∘ round ∘ log2)(ind_size)
+    vertex_scaler::Function = (prod_size) -> 1000 * (Int ∘ round ∘ log2)(prod_size)
 end
 
 function EinExprs.einexpr(config::HyPar, path)
@@ -23,8 +23,8 @@ function EinExprs.einexpr(config::HyPar, path)
     incidence_matrix = sparse(I, J, V)
 
     # NOTE indices in `inds` should be in the same order as unique indices appear by iterating on `path.args` because `∪` retains order
-    edge_weights = map(ind -> config.edge_weight_scaling(size(path, ind)), inds)
-    vertex_weights = map(tensor -> config.vertex_weight_scaling(prod(size(tensor))), path.args)
+    edge_weights = map(ind -> (config.edge_scaler ∘ size)(path, ind), inds)
+    vertex_weights = map(tensor -> (config.vertex_scaler ∘ length)(tensor), path.args)
 
     hypergraph = KaHyPar.HyperGraph(incidence_matrix, vertex_weights, edge_weights)
 

--- a/src/Optimizers/KaHyPar.jl
+++ b/src/Optimizers/KaHyPar.jl
@@ -7,8 +7,8 @@ using KaHyPar
     imbalance::Float32 = 0.03
     stop::Function = <=(2) ∘ length ∘ Base.Fix1(getfield, :args)
     configuration::Union{Nothing,Symbol,String} = nothing
-    edge_scaler::Function = *(1000) ∘ Int ∘ round ∘ log2
-    vertex_scaler::Function = *(1000) ∘ Int ∘ round ∘ log2
+    edge_scaler::Function = Base.Fix1(*, 1000) ∘ Int ∘ round ∘ log2
+    vertex_scaler::Function = Base.Fix1(*, 1000) ∘ Int ∘ round ∘ log2
 end
 
 function EinExprs.einexpr(config::HyPar, path)

--- a/src/Optimizers/KaHyPar.jl
+++ b/src/Optimizers/KaHyPar.jl
@@ -7,6 +7,8 @@ using KaHyPar
     imbalance::Float32 = 0.03
     stop::Function = <=(2) ∘ length ∘ Base.Fix1(getfield, :args)
     configuration::Union{Nothing,Symbol,String} = nothing
+    edge_weight_scaling::Function = (ind_size) -> 1000 * Int(round(log2(ind_size)))
+    vertex_weight_scaling::Function = (prod_size) -> 1000 * Int(round(log2(prod_size)))
 end
 
 function EinExprs.einexpr(config::HyPar, path)
@@ -21,8 +23,8 @@ function EinExprs.einexpr(config::HyPar, path)
     incidence_matrix = sparse(I, J, V)
 
     # NOTE indices in `inds` should be in the same order as unique indices appear by iterating on `path.args` because `∪` retains order
-    edge_weights = map(Base.Fix1(size, path), inds)
-    vertex_weights = ones(Int, length(path.args))
+    edge_weights = map(ind -> config.edge_weight_scaling(size(path, ind)), inds)
+    vertex_weights = map(tensor -> config.vertex_weight_scaling(prod(size(tensor))), path.args)
 
     hypergraph = KaHyPar.HyperGraph(incidence_matrix, vertex_weights, edge_weights)
 

--- a/src/Optimizers/KaHyPar.jl
+++ b/src/Optimizers/KaHyPar.jl
@@ -7,8 +7,8 @@ using KaHyPar
     imbalance::Float32 = 0.03
     stop::Function = <=(2) ∘ length ∘ Base.Fix1(getfield, :args)
     configuration::Union{Nothing,Symbol,String} = nothing
-    edge_scaler::Function = (ind_size) -> 1000 * (Int ∘ round ∘ log2)(ind_size)
-    vertex_scaler::Function = (prod_size) -> 1000 * (Int ∘ round ∘ log2)(prod_size)
+    edge_scaler::Function = *(1000) ∘ Int ∘ round ∘ log2
+    vertex_scaler::Function = *(1000) ∘ Int ∘ round ∘ log2
 end
 
 function EinExprs.einexpr(config::HyPar, path)
@@ -23,7 +23,7 @@ function EinExprs.einexpr(config::HyPar, path)
     incidence_matrix = sparse(I, J, V)
 
     # NOTE indices in `inds` should be in the same order as unique indices appear by iterating on `path.args` because `∪` retains order
-        edge_weights = map(ind -> (config.edge_scaler ∘ Base.Fix1(size, path))(ind), inds)
+        edge_weights = map(config.edge_scaler ∘ Base.Fix1(size, path), inds)
         vertex_weights = map(config.vertex_scaler ∘ length, path.args)
 
     hypergraph = KaHyPar.HyperGraph(incidence_matrix, vertex_weights, edge_weights)

--- a/src/Optimizers/KaHyPar.jl
+++ b/src/Optimizers/KaHyPar.jl
@@ -23,8 +23,8 @@ function EinExprs.einexpr(config::HyPar, path)
     incidence_matrix = sparse(I, J, V)
 
     # NOTE indices in `inds` should be in the same order as unique indices appear by iterating on `path.args` because `∪` retains order
-    edge_weights = map(ind -> (config.edge_scaler ∘ size)(path, ind), inds)
-    vertex_weights = map(tensor -> (config.vertex_scaler ∘ length)(tensor), path.args)
+        edge_weights = map(ind -> (config.edge_scaler ∘ Base.Fix1(size, path))(ind), inds)
+        vertex_weights = map(config.vertex_scaler ∘ length, path.args)
 
     hypergraph = KaHyPar.HyperGraph(incidence_matrix, vertex_weights, edge_weights)
 

--- a/test/KaHyPar_test.jl
+++ b/test/KaHyPar_test.jl
@@ -10,7 +10,7 @@
             EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
         ]
 
-        path = einexpr(HyPar(imbakance=0.42), EinExpr(Symbol[], tensors))
+        path = einexpr(HyPar(imbalance=0.42), EinExpr(Symbol[], tensors))
 
         @test path isa EinExpr
 

--- a/test/KaHyPar_test.jl
+++ b/test/KaHyPar_test.jl
@@ -41,10 +41,10 @@
             EinExpr([:a, :C, :d], Dict(:a => 3, :d => 6, :C => 4)),
         ]
 
-        path = einexpr(HyPar, EinExpr(Symbol[], tensors))
+        path = einexpr(HyPar(imbalance=0.45), EinExpr(Symbol[], tensors))
 
         @test path isa EinExpr
 
-        @test mapreduce(flops, +, Branches(path)) == 31653164
+        @test mapreduce(flops, +, Branches(path)) == 19099592
     end
 end

--- a/test/KaHyPar_test.jl
+++ b/test/KaHyPar_test.jl
@@ -10,7 +10,7 @@
             EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
         ]
 
-        path = einexpr(HyPar, EinExpr(Symbol[], tensors))
+        path = einexpr(HyPar(imbakance=0.42), EinExpr(Symbol[], tensors))
 
         @test path isa EinExpr
 


### PR DESCRIPTION
### Summary
This PR enhances the `HyPar` optimizer by adding two functions on its configuration that compute the weights for both `edges` and `vertices`. The functions `edge_weight_scaling` and `vertex_weight_scaling` enable the user to choose whether to apply a `log`, `linear`, `exp`, ... scaling into the size of the index (for the edges) or the product of the sizes of all the present indexes (for the vertices).