### PR TITLE
Decouple `size` dictionary from `EinExprs`

### DIFF
--- a/benchmark/make.jl
+++ b/benchmark/make.jl
@@ -15,18 +15,15 @@ suite["greedy"] = BenchmarkGroup([])
 suite["kahypar"] = BenchmarkGroup([])
 
 # BENCHMARK 1
-expr = EinExpr(
-    Symbol[],
-    [
-        EinExpr([:j, :b, :i, :h], Dict(i => 2 for i in [:j, :b, :i, :h])),
-        EinExpr([:a, :c, :e, :f], Dict(i => 2 for i in [:a, :c, :e, :f])),
-        EinExpr([:j], Dict(i => 2 for i in [:j])),
-        EinExpr([:e, :a, :g], Dict(i => 2 for i in [:e, :a, :g])),
-        EinExpr([:f, :b], Dict(i => 2 for i in [:f, :b])),
-        EinExpr([:i, :h, :d], Dict(i => 2 for i in [:i, :h, :d])),
-        EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
-    ],
-)
+expr = sum([
+    EinExpr([:j, :b, :i, :h], Dict(i => 2 for i in [:j, :b, :i, :h])),
+    EinExpr([:a, :c, :e, :f], Dict(i => 2 for i in [:a, :c, :e, :f])),
+    EinExpr([:j], Dict(i => 2 for i in [:j])),
+    EinExpr([:e, :a, :g], Dict(i => 2 for i in [:e, :a, :g])),
+    EinExpr([:f, :b], Dict(i => 2 for i in [:f, :b])),
+    EinExpr([:i, :h, :d], Dict(i => 2 for i in [:i, :h, :d])),
+    EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
+])
 
 suite["naive"][1] = @benchmarkable einexpr(EinExprs.Naive(), $expr)
 suite["exhaustive"][1] = @benchmarkable einexpr(Exhaustive(), $expr)
@@ -41,7 +38,7 @@ D = EinExpr([:c, :h, :d, :i], Dict(:c => 2, :h => 2, :d => 2, :i => 2))
 E = EinExpr([:f, :i, :g, :j], Dict(:f => 2, :i => 2, :g => 2, :j => 2))
 F = EinExpr([:B, :h, :k, :l], Dict(:B => 2, :h => 2, :k => 2, :l => 2))
 G = EinExpr([:j, :k, :l, :D], Dict(:j => 2, :k => 2, :l => 2, :D => 2))
-expr = EinExpr([:A, :B, :C, :D], [A, B, C, D, E, F, G])
+expr = sum([A, B, C, D, E, F, G], skip = [:A, :B, :C, :D])
 
 suite["naive"][2] = @benchmarkable einexpr(EinExprs.Naive(), $expr)
 suite["exhaustive"][2] = @benchmarkable einexpr(Exhaustive(), $expr)

--- a/ext/EinExprsMakieExt.jl
+++ b/ext/EinExprsMakieExt.jl
@@ -15,13 +15,13 @@ const MAX_EDGE_WIDTH = 10.0
 const MAX_ARROW_SIZE = 35.0
 const MAX_NODE_SIZE = 40.0
 
-function Makie.plot(path::EinExpr; kwargs...)
+function Makie.plot(path::SizedEinExpr; kwargs...)
     f = Figure()
     ax, p = plot!(f[1, 1], path; kwargs...)
     return Makie.FigureAxisPlot(f, ax, p)
 end
 
-function Makie.plot!(f::Union{Figure,GridPosition}, path::EinExpr; kwargs...)
+function Makie.plot!(f::Union{Figure,GridPosition}, path::SizedEinExpr; kwargs...)
     ax = if haskey(kwargs, :layout) && __networklayout_dim(kwargs[:layout]) == 3
         Axis3(f[1, 1])
     else
@@ -65,13 +65,13 @@ end
 # TODO replace `to_colormap(:viridis)[begin:end-10]` with a custom colormap
 function Makie.plot!(
     ax::Union{Axis,Axis3},
-    path::EinExpr;
+    path::SizedEinExpr;
     colormap = to_colormap(:viridis)[begin:end-10],
     inds = false,
     kwargs...,
 )
-    handles = IdDict(obj => i for (i, obj) in enumerate(PostOrderDFS(path)))
-    graph = SimpleDiGraph([Edge(handles[from], handles[to]) for to in Branches(path) for from in to.args])
+    handles = IdDict(obj => i for (i, obj) in enumerate(PostOrderDFS(path.path)))
+    graph = SimpleDiGraph([Edge(handles[from], handles[to]) for to in Branches(path.path) for from in to.args])
 
     lin_size = length.(PostOrderDFS(path))[1:end-1]
     lin_flops = map(max, Iterators.repeated(1), Iterators.map(flops, PostOrderDFS(path)))

--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -22,8 +22,8 @@ flops(expr::EinExpr, size) = flops(SizedEinExpr(expr, size))
 
 Count the amount of memory that will be freed after performing the contraction of the root of the `path` tree.
 """
-function removedsize(sexpr::SizedEinExpr)
-    mapreduce(prod ∘ Base.Fix2(size, sexpr.size), +, sexpr.args) - prod(size(sexpr, sexpr.size))
+removedsize(sexpr::SizedEinExpr) = -length(sexpr) + mapreduce(+, sexpr.args) do arg
+    length(SizedEinExpr(arg, sexpr.size))
 end
 
 removedsize(expr::EinExpr, size) = removedsize(SizedEinExpr(expr, size))

--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -25,3 +25,8 @@ end
 Count the rank reduction after performing the contraction of the root of the `path` tree.
 """
 removedrank(expr::EinExpr, _) = mapreduce(ndims, max, expr.args) - ndims(expr)
+
+for f in [:flops, :removedsize]
+    @eval $f(sizedict::Dict{Symbol}) = Base.Fix2($f, sizedict)
+end
+removedrank(::Dict) = Base.Fix2(removedrank, nothing)

--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -7,7 +7,7 @@ flops(expr::EinExpr, sizedict) =
     if length(expr.args) == 0 || length(expr.args) == 1 && isempty(suminds(expr))
         0
     else
-        mapreduce(i -> sizedict[i], *, Iterators.flatten((head(expr), suminds(expr))), init = one(BigInt))
+        mapreduce(Base.Fix1(getindex, sizedict), *, Iterators.flatten((head(expr), suminds(expr))), init = one(BigInt))
     end
 
 """

--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -3,30 +3,41 @@
 
 Count the number of mathematical operations will be performed by the contraction of the root of the `path` tree.
 """
-flops(expr::EinExpr, sizedict) =
-    if length(expr.args) == 0 || length(expr.args) == 1 && isempty(suminds(expr))
+flops(sexpr::SizedEinExpr) =
+    if nargs(sexpr) == 0 || nargs(sexpr) == 1 && isempty(suminds(sexpr))
         0
     else
-        mapreduce(Base.Fix1(getindex, sizedict), *, Iterators.flatten((head(expr), suminds(expr))), init = one(BigInt))
+        mapreduce(
+            Base.Fix1(getindex, sexpr.size),
+            *,
+            Iterators.flatten((head(sexpr), suminds(sexpr))),
+            init = one(BigInt),
+        )
     end
+
+flops(expr::EinExpr, size) = flops(SizedEinExpr(expr, size))
 
 """
     removedsize(path::EinExpr)
 
 Count the amount of memory that will be freed after performing the contraction of the root of the `path` tree.
 """
-function removedsize(expr::EinExpr, sizedict)
-    mapreduce(prod ∘ Base.Fix2(size, sizedict), +, expr.args) - prod(size(expr, sizedict))
+function removedsize(sexpr::SizedEinExpr)
+    mapreduce(prod ∘ Base.Fix2(size, sexpr.size), +, sexpr.args) - prod(size(sexpr, sexpr.size))
 end
+
+removedsize(expr::EinExpr, size) = removedsize(SizedEinExpr(expr, size))
 
 """
     removedrank(path::EinExpr)
 
 Count the rank reduction after performing the contraction of the root of the `path` tree.
 """
-removedrank(expr::EinExpr, _) = mapreduce(ndims, max, expr.args) - ndims(expr)
+removedrank(expr::EinExpr) = mapreduce(ndims, max, expr.args) - ndims(expr)
+removedrank(expr::EinExpr, _) = removedrank(expr)
+removedrank(sexpr::SizedEinExpr, _) = removedrank(sexpr.path)
 
 for f in [:flops, :removedsize]
     @eval $f(sizedict::Dict{Symbol}) = Base.Fix2($f, sizedict)
 end
-removedrank(::Dict) = Base.Fix2(removedrank, nothing)
+removedrank(::Dict) = removedrank

--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -3,11 +3,11 @@
 
 Count the number of mathematical operations will be performed by the contraction of the root of the `path` tree.
 """
-flops(expr::EinExpr) =
+flops(expr::EinExpr, sizedict) =
     if length(expr.args) == 0 || length(expr.args) == 1 && isempty(suminds(expr))
         0
     else
-        mapreduce(Base.Fix1(size, expr), *, Iterators.flatten((head(expr), suminds(expr))), init = one(BigInt))
+        mapreduce(i -> sizedict[i], *, Iterators.flatten((head(expr), suminds(expr))), init = one(BigInt))
     end
 
 """
@@ -15,11 +15,13 @@ flops(expr::EinExpr) =
 
 Count the amount of memory that will be freed after performing the contraction of the root of the `path` tree.
 """
-removedsize(expr::EinExpr) = mapreduce(prod ∘ size, +, expr.args) - prod(size(expr))
+function removedsize(expr::EinExpr, sizedict)
+    mapreduce(prod ∘ Base.Fix2(size, sizedict), +, expr.args) - prod(size(expr, sizedict))
+end
 
 """
     removedrank(path::EinExpr)
 
 Count the rank reduction after performing the contraction of the root of the `path` tree.
 """
-removedrank(expr::EinExpr) = mapreduce(ndims, max, expr.args) - ndims(expr)
+removedrank(expr::EinExpr, _) = mapreduce(ndims, max, expr.args) - ndims(expr)

--- a/src/EinExpr.jl
+++ b/src/EinExpr.jl
@@ -7,6 +7,7 @@ Base.@kwdef struct EinExpr
     args::Vector{EinExpr} = EinExpr[]
 end
 
+EinExpr(head) = EinExpr(head, EinExpr[])
 EinExpr(head, args::AbstractVecOrTuple{<:AbstractVecOrTuple{Symbol}}) = EinExpr(head, map(EinExpr, args))
 
 EinExpr(head::NTuple, args) = EinExpr(collect(head), args)

--- a/src/EinExpr.jl
+++ b/src/EinExpr.jl
@@ -3,7 +3,7 @@ using DataStructures: DefaultDict
 using AbstractTrees
 
 Base.@kwdef struct EinExpr
-    head::ImmutableVector{Symbol,Vector{Symbol}}
+    head::Vector{Symbol}
     args::Vector{EinExpr} = EinExpr[]
 end
 

--- a/src/EinExpr.jl
+++ b/src/EinExpr.jl
@@ -32,6 +32,8 @@ See also: [`head`](@ref).
 """
 args(path::EinExpr) = path.args
 
+nargs(path::EinExpr) = length(path.args)
+
 """
     inds(path)
 

--- a/src/EinExprs.jl
+++ b/src/EinExprs.jl
@@ -5,6 +5,9 @@ export EinExpr
 export head, args, inds, hyperinds, suminds, parsuminds, collapse!, contractorder, select, neighbours
 export Branches, branches, leaves
 
+include("SizedEinExpr.jl")
+export SizedEinExpr
+
 include("Counters.jl")
 export flops, removedsize
 

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -39,7 +39,7 @@ function __einexpr_exhaustive_it(
     outer,
     leader;
     cache = Dict{Vector{Symbol},BigInt}(),
-    hashyperinds = any(hyperinds(path)),
+    hashyperinds = !isempty(hyperinds(path)),
 ) where {Metric}
     if nargs(path) <= 2
         #= mapreduce(metric, +, Branches(path, inverse = true), init = BigInt(0))) =#

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -22,23 +22,31 @@ The algorithm has a ``\mathcal{O}(n!)`` time complexity if `outer = true` and ``
     outer::Bool = false
 end
 
-function einexpr(config::Exhaustive, path; cost = BigInt(0))
-    leader = Ref{NamedTuple{(:path, :cost),Tuple{EinExpr,BigInt}}}((;
-        path = einexpr(Naive(), path),
-        cost = mapreduce(config.metric, +, Branches(einexpr(Naive(), path), inverse = true), init = BigInt(0))::BigInt,
-    ))
-    cache = Dict{Vector{Symbol},BigInt}()
-    __einexpr_exhaustive_it(path, cost, config.metric, config.outer, leader, cache)
-    return leader[].path
-end
+function einexpr(config::Exhaustive, path, sizedict; cost = BigInt(0))
+    metric = Base.Fix2(config.metric, sizedict)
 
-function __einexpr_exhaustive_it(path, cost, metric, outer, leader, cache)
-    if length(path.args) == 1
-        # remove identity einsum (i.e. "i...->i...")
-        path = path.args[1]
+    leader = (; path = einexpr(Naive(), path), cost = mapreduce(config.metric, +, Branches(einexpr(Naive(), path))))
+    cache = Dict{Vector{ImmutableVector{Symbol,Vector{Symbol}}},BigInt}()
 
-        leader[] = (; path, cost = mapreduce(metric, +, Branches(path, inverse = true), init = BigInt(0))::BigInt)
-        return
+    function __einexpr_iterate(path, cost)
+        if length(path.args) <= 2
+            leader = (; path = path, cost = mapreduce(metric, +, Branches(path)))
+            return
+        end
+
+        for (i, j) in combinations(args(path), 2)
+            !config.outer && isdisjoint(head(i), head(j)) && continue
+            candidate = sum([i, j], skip = path.head ∪ hyperinds(path))
+
+            # prune paths based on metric
+            new_cost = cost + get!(cache, head.(candidate.args)) do
+                metric(candidate)
+            end
+            new_cost >= leader.cost && continue
+
+            new_path = EinExpr(head(path), [candidate, filter(∉([i, j]), args(path))...])
+            __einexpr_iterate(new_path, new_cost)
+        end
     end
 
     for (i, j) in combinations(args(path), 2)

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -42,7 +42,8 @@ function __einexpr_exhaustive_it(
     hashyperinds = any(hyperinds(path)),
 ) where {Metric}
     if nargs(path) <= 2
-        leader[] = (; path = path, cost = cost) #= mapreduce(metric, +, Branches(path, inverse = true), init = BigInt(0))) =#
+        #= mapreduce(metric, +, Branches(path, inverse = true), init = BigInt(0))) =#
+        leader[] = (; path = path, cost = cost)
         return
     end
 

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -49,7 +49,6 @@ function __einexpr_exhaustive_it(
 
     for (i, j) in combinations(args(path), 2)
         !outer && isdisjoint(head(i), head(j)) && continue
-        # candidate = sum([i, j]; skip = hashyperinds ? path.head ∪ hyperinds(path) : path.head)
         candidate = sum(i, j; skip = hashyperinds ? path.head ∪ hyperinds(path) : path.head)
 
         # prune paths based on metric

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -22,35 +22,41 @@ The algorithm has a ``\mathcal{O}(n!)`` time complexity if `outer = true` and ``
     outer::Bool = false
 end
 
-function einexpr(config::Exhaustive, path, sizedict; cost = BigInt(0))
-    metric = config.metric(sizedict)
-    leader = Ref{NamedTuple{(:path, :cost),Tuple{EinExpr,BigInt}}}((;
+function einexpr(config::Exhaustive, path; cost = BigInt(0))
+    # metric = Base.Fix2(config.metric, path.size)
+    leader = Ref((;
         path = einexpr(Naive(), path),
-        cost = mapreduce(metric, +, Branches(einexpr(Naive(), path), inverse = true), init = BigInt(0))::BigInt,
+        cost = mapreduce(config.metric, +, Branches(einexpr(Naive(), path), inverse = true), init = BigInt(0))::BigInt,
     ))
-    cache = Dict{Vector{Symbol},BigInt}()
-    __einexpr_exhaustive_it(path, cost, metric, config.outer, leader, cache)
+    __einexpr_exhaustive_it(path, cost, config.metric, config.outer, leader)
     return leader[].path
 end
 
-function __einexpr_exhaustive_it(path, cost, metric, outer, leader, cache)
-    if length(path.args) <= 2
-        leader[] =
-            (; path = path, cost = mapreduce(metric, +, Branches(path, inverse = true), init = BigInt(0))::BigInt)
+function __einexpr_exhaustive_it(
+    path,
+    cost,
+    metric,
+    outer,
+    leader;
+    cache = Dict{Vector{Symbol},BigInt}(),
+    hashyperinds = any(hyperinds(path)),
+)
+    if nargs(path) <= 2
+        leader[] = (; path = path, cost = cost) #= mapreduce(metric, +, Branches(path, inverse = true), init = BigInt(0))) =#
         return
     end
 
     for (i, j) in combinations(args(path), 2)
         !outer && isdisjoint(head(i), head(j)) && continue
-        candidate = sum([i, j], skip = path.head ∪ hyperinds(path))
+        candidate = sum([i, j]; skip = hashyperinds ? path.head ∪ hyperinds(path) : path.head)
 
         # prune paths based on metric
         new_cost = cost + get!(cache, head(candidate)) do
-            metric(candidate)
+            metric(SizedEinExpr(candidate, path.size))
         end
         new_cost >= leader[].cost && continue
 
-        new_path = EinExpr(head(path), [candidate, filter(∉([i, j]), args(path))...])
-        __einexpr_exhaustive_it(new_path, new_cost, metric, outer, leader, cache)
+        new_path = SizedEinExpr(EinExpr(head(path), [candidate, filter(∉([i, j]), args(path))...]), path.size) # sum([candidate, filter(∉([i, j]), args(path))...], skip = path.head)
+        __einexpr_exhaustive_it(new_path, new_cost, metric, outer, leader; cache, hashyperinds)
     end
 end

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -23,7 +23,7 @@ The algorithm has a ``\mathcal{O}(n!)`` time complexity if `outer = true` and ``
 end
 
 function einexpr(config::Exhaustive, path, sizedict; cost = BigInt(0))
-    metric = Base.Fix2(config.metric, sizedict)
+    metric = config.metric(sizedict)
 
     leader =
         (; path = einexpr(Naive(), path), cost = mapreduce(metric, +, Branches(einexpr(Naive(), path), inverse = true)))

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -25,12 +25,12 @@ end
 function einexpr(config::Exhaustive, path, sizedict; cost = BigInt(0))
     metric = Base.Fix2(config.metric, sizedict)
 
-    leader = (; path = einexpr(Naive(), path), cost = mapreduce(metric, +, Branches(einexpr(Naive(), path))))
+    leader = (; path = einexpr(Naive(), path), cost = mapreduce(metric, +, PreOrderDFS(einexpr(Naive(), path))))
     cache = Dict{ImmutableVector{Symbol,Vector{Symbol}},BigInt}()
 
     function __einexpr_iterate(path, cost)
         if length(path.args) <= 2
-            leader = (; path = path, cost = mapreduce(metric, +, Branches(path)))
+            leader = (; path = path, cost = mapreduce(metric, +, PreOrderDFS(path)))
             return
         end
 

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -28,19 +28,19 @@ function einexpr(config::Exhaustive, path; cost = BigInt(0))
         path = einexpr(Naive(), path),
         cost = mapreduce(config.metric, +, Branches(einexpr(Naive(), path), inverse = true), init = BigInt(0))::BigInt,
     ))
-    __einexpr_exhaustive_it(path, cost, config.metric, config.outer, leader)
+    __einexpr_exhaustive_it(path, cost, Val(config.metric), config.outer, leader)
     return leader[].path
 end
 
 function __einexpr_exhaustive_it(
     path,
     cost,
-    metric,
+    @specialize(metric::Val{Metric}),
     outer,
     leader;
     cache = Dict{Vector{Symbol},BigInt}(),
     hashyperinds = any(hyperinds(path)),
-)
+) where {Metric}
     if nargs(path) <= 2
         leader[] = (; path = path, cost = cost) #= mapreduce(metric, +, Branches(path, inverse = true), init = BigInt(0))) =#
         return
@@ -52,7 +52,7 @@ function __einexpr_exhaustive_it(
 
         # prune paths based on metric
         new_cost = cost + get!(cache, head(candidate)) do
-            metric(SizedEinExpr(candidate, path.size))
+            Metric(SizedEinExpr(candidate, path.size))
         end
         new_cost >= leader[].cost && continue
 

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -48,7 +48,8 @@ function __einexpr_exhaustive_it(
 
     for (i, j) in combinations(args(path), 2)
         !outer && isdisjoint(head(i), head(j)) && continue
-        candidate = sum([i, j]; skip = hashyperinds ? path.head ∪ hyperinds(path) : path.head)
+        # candidate = sum([i, j]; skip = hashyperinds ? path.head ∪ hyperinds(path) : path.head)
+        candidate = sum(i, j; skip = hashyperinds ? path.head ∪ hyperinds(path) : path.head)
 
         # prune paths based on metric
         new_cost = cost + get!(cache, head(candidate)) do

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -25,8 +25,8 @@ end
 function einexpr(config::Exhaustive, path, sizedict; cost = BigInt(0))
     metric = Base.Fix2(config.metric, sizedict)
 
-    leader = (; path = einexpr(Naive(), path), cost = mapreduce(config.metric, +, Branches(einexpr(Naive(), path))))
-    cache = Dict{Vector{ImmutableVector{Symbol,Vector{Symbol}}},BigInt}()
+    leader = (; path = einexpr(Naive(), path), cost = mapreduce(metric, +, Branches(einexpr(Naive(), path))))
+    cache = Dict{ImmutableVector{Symbol,Vector{Symbol}},BigInt}()
 
     function __einexpr_iterate(path, cost)
         if length(path.args) <= 2
@@ -39,7 +39,7 @@ function einexpr(config::Exhaustive, path, sizedict; cost = BigInt(0))
             candidate = sum([i, j], skip = path.head ∪ hyperinds(path))
 
             # prune paths based on metric
-            new_cost = cost + get!(cache, head.(candidate.args)) do
+            new_cost = cost + get!(cache, head(candidate)) do
                 metric(candidate)
             end
             new_cost >= leader.cost && continue

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -28,7 +28,7 @@ function einexpr(config::Exhaustive, path, sizedict; cost = BigInt(0))
         path = einexpr(Naive(), path),
         cost = mapreduce(metric, +, Branches(einexpr(Naive(), path), inverse = true), init = BigInt(0))::BigInt,
     ))
-    cache = Dict{ImmutableVector{Symbol,Vector{Symbol}},BigInt}()
+    cache = Dict{Vector{Symbol},BigInt}()
     __einexpr_exhaustive_it(path, cost, metric, config.outer, leader, cache)
     return leader[].path
 end

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -47,7 +47,7 @@ function __einexpr_exhaustive_it(
         return
     end
 
-    for (i, j) in combinations(args(path), 2)
+    for (i, j) in combinations(path.args, 2)
         !outer && isdisjoint(head(i), head(j)) && continue
         candidate = sum(i, j; skip = hashyperinds ? path.head ∪ hyperinds(path) : path.head)
 
@@ -57,7 +57,7 @@ function __einexpr_exhaustive_it(
         end
         new_cost >= leader[].cost && continue
 
-        new_path = SizedEinExpr(EinExpr(head(path), [candidate, filter(∉([i, j]), args(path))...]), path.size) # sum([candidate, filter(∉([i, j]), args(path))...], skip = path.head)
+        new_path = SizedEinExpr(EinExpr(head(path), [candidate, filter(∉([i, j]), path.args)...]), path.size) # sum([candidate, filter(∉([i, j]), args(path))...], skip = path.head)
         __einexpr_exhaustive_it(new_path, new_cost, metric, outer, leader; cache, hashyperinds)
     end
 end

--- a/src/Optimizers/Exhaustive.jl
+++ b/src/Optimizers/Exhaustive.jl
@@ -25,12 +25,13 @@ end
 function einexpr(config::Exhaustive, path, sizedict; cost = BigInt(0))
     metric = Base.Fix2(config.metric, sizedict)
 
-    leader = (; path = einexpr(Naive(), path), cost = mapreduce(metric, +, PreOrderDFS(einexpr(Naive(), path))))
+    leader =
+        (; path = einexpr(Naive(), path), cost = mapreduce(metric, +, Branches(einexpr(Naive(), path), inverse = true)))
     cache = Dict{ImmutableVector{Symbol,Vector{Symbol}},BigInt}()
 
     function __einexpr_iterate(path, cost)
         if length(path.args) <= 2
-            leader = (; path = path, cost = mapreduce(metric, +, PreOrderDFS(path)))
+            leader = (; path = path, cost = mapreduce(metric, +, Branches(path, inverse = true)))
             return
         end
 

--- a/src/Optimizers/Greedy.jl
+++ b/src/Optimizers/Greedy.jl
@@ -68,6 +68,4 @@ function einexpr(config::Greedy, path, sizedict)
     return path
 end
 
-function einexpr(config::Greedy, path::SizedEinExpr)
-    return einexpr(config, path.path, path.size)
-end
+einexpr(config::Greedy, path::SizedEinExpr) = SizedEinExpr(einexpr(config, path.path, path.size), path.size)

--- a/src/Optimizers/Greedy.jl
+++ b/src/Optimizers/Greedy.jl
@@ -28,7 +28,7 @@ The implementation uses a binary heaptree to sort candidate pairwise tensor cont
 end
 
 function einexpr(config::Greedy, path, sizedict)
-    metric = Base.Fix2(config.metric, sizedict)
+    metric = config.metric(sizedict)
 
     # generate initial candidate contractions
     queue = MutableBinaryHeap{Tuple{Float64,EinExpr}}(

--- a/src/Optimizers/Greedy.jl
+++ b/src/Optimizers/Greedy.jl
@@ -27,7 +27,9 @@ The implementation uses a binary heaptree to sort candidate pairwise tensor cont
     outer::Bool = false
 end
 
-function einexpr(config::Greedy, path)
+function einexpr(config::Greedy, path, sizedict)
+    metric = Base.Fix2(config.metric, sizedict)
+
     # generate initial candidate contractions
     queue = MutableBinaryHeap{Tuple{Float64,EinExpr}}(
         Base.By(first, Base.Reverse),
@@ -36,7 +38,7 @@ function einexpr(config::Greedy, path)
         ) do (a, b)
             # TODO don't consider outer products
             candidate = sum([a, b], skip = path.head ∪ hyperinds(path))
-            weight = config.metric(candidate)
+            weight = metric(candidate)
             (weight, candidate)
         end,
     )
@@ -55,7 +57,7 @@ function einexpr(config::Greedy, path)
         for other in Iterators.filter(other -> config.outer || !isdisjoint(winner.head, other.head), path.args)
             # TODO don't consider outer products
             candidate = sum([winner, other], skip = path.head ∪ hyperinds(path))
-            weight = config.metric(candidate)
+            weight = metric(candidate)
             push!(queue, (weight, candidate))
         end
 

--- a/src/Optimizers/Greedy.jl
+++ b/src/Optimizers/Greedy.jl
@@ -43,7 +43,7 @@ function einexpr(config::Greedy, path, sizedict)
         end,
     )
 
-    while length(path.args) > 2 && length(queue) > 1
+    while nargs(path) > 2 && length(queue) > 1
         # choose winner
         _, winner = config.choose(queue)
 
@@ -66,4 +66,8 @@ function einexpr(config::Greedy, path, sizedict)
     end
 
     return path
+end
+
+function einexpr(config::Greedy, path::SizedEinExpr)
+    return einexpr(config, path.path, path.size)
 end

--- a/src/Optimizers/Naive.jl
+++ b/src/Optimizers/Naive.jl
@@ -1,12 +1,14 @@
+using AbstractTrees
+
 struct Naive <: Optimizer end
 
 einexpr(::Naive, path, _) = einexpr(Naive(), path)
 
 function einexpr(::Naive, path)
-    hist = Dict(i => count(∋(i) ∘ head, path.args) for i in hyperinds(path))
+    hist = Dict(i => count(∋(i) ∘ head, args(path)) for i in hyperinds(path))
 
-    foldl(path.args) do a, b
-        expr = sum([a, b], skip = path.head ∪ collect(keys(hist)))
+    foldl(args(path)) do a, b
+        expr = sum([a, b], skip = head(path) ∪ collect(keys(hist)))
 
         for i in Iterators.filter(∈(keys(hist)), ∩(head(a), head(b)))
             hist[i] -= 1
@@ -16,3 +18,5 @@ function einexpr(::Naive, path)
         return expr
     end
 end
+
+einexpr(::Naive, path::SizedEinExpr) = SizedEinExpr(einexpr(Naive(), path.path), path.size)

--- a/src/Optimizers/Naive.jl
+++ b/src/Optimizers/Naive.jl
@@ -1,5 +1,7 @@
 struct Naive <: Optimizer end
 
+einexpr(::Naive, path, _) = einexpr(Naive(), path)
+
 function einexpr(::Naive, path)
     hist = Dict(i => count(∋(i) ∘ head, path.args) for i in hyperinds(path))
 

--- a/src/Optimizers/Optimizers.jl
+++ b/src/Optimizers/Optimizers.jl
@@ -3,7 +3,7 @@ abstract type Optimizer end
 function einexpr end
 
 einexpr(T::Type{<:Optimizer}, args...; kwargs...) = einexpr(T(; kwargs...), args...)
-einexpr(config::Optimizer, expr) = einexpr(config, expr)
+einexpr(config::Optimizer, expr, sizedict) = einexpr(config, expr, sizedict)
 
 include("Naive.jl")
 include("Exhaustive.jl")

--- a/src/SizedEinExpr.jl
+++ b/src/SizedEinExpr.jl
@@ -28,6 +28,7 @@ Base.:(==)(a::SizedEinExpr, b::SizedEinExpr) = a.path == b.path && a.size == b.s
 Base.ndims(sexpr::SizedEinExpr) = ndims(sexpr.path)
 
 Base.size(sexpr::SizedEinExpr) = size(sexpr.path, sexpr.size)
+Base.size(sexpr::SizedEinExpr, i) = sexpr.size[i]
 Base.length(sexpr::SizedEinExpr) = length(sexpr.path, sexpr.size)
 
 collapse!(sexpr::SizedEinExpr) = collapse!(sexpr.path)

--- a/src/SizedEinExpr.jl
+++ b/src/SizedEinExpr.jl
@@ -13,7 +13,16 @@ end
 EinExpr(path::Vector{Symbol}, size::Dict{Symbol}) = SizedEinExpr(EinExpr(path), size)
 
 head(sexpr::SizedEinExpr) = head(sexpr.path)
-args(sexpr::SizedEinExpr) = sexpr.path.args # map(Base.Fix2(SizedEinExpr, sexpr.size), sexpr.path.args)
+
+"""
+    args(sexpr::SizedEinExpr)
+
+# Note
+
+Unlike `args(::EinExpr)`, this function returns `SizedEinExpr` objects.
+"""
+args(sexpr::SizedEinExpr) = map(Base.Fix2(SizedEinExpr, sexpr.size), sexpr.path.args) # sexpr.path.args
+
 nargs(sexpr::SizedEinExpr) = nargs(sexpr.path)
 inds(sexpr::SizedEinExpr) = inds(sexpr.path)
 
@@ -59,7 +68,7 @@ Base.IteratorEltype(::Type{<:TreeIterator{SizedEinExpr}}) = Base.HasEltype()
 Base.eltype(::Type{<:TreeIterator{SizedEinExpr}}) = SizedEinExpr
 
 # AbstractTrees interface and traits
-AbstractTrees.children(sexpr::SizedEinExpr) = map(Base.Fix2(SizedEinExpr, sexpr.size), args(sexpr))
+AbstractTrees.children(sexpr::SizedEinExpr) = args(sexpr)
 AbstractTrees.childtype(::Type{SizedEinExpr}) = SizedEinExpr
 AbstractTrees.childrentype(::Type{SizedEinExpr}) = Vector{SizedEinExpr}
 AbstractTrees.childstatetype(::Type{SizedEinExpr}) = Int

--- a/src/SizedEinExpr.jl
+++ b/src/SizedEinExpr.jl
@@ -1,0 +1,70 @@
+using AbstractTrees
+
+struct SizedEinExpr
+    path::EinExpr
+    size::Dict{Symbol,Int}
+
+    function SizedEinExpr(path, size)
+        # inds(path) ⊆ keys(size) || throw(ArgumentError(""))
+        new(path, size)
+    end
+end
+
+EinExpr(path::Vector{Symbol}, size::Dict{Symbol}) = SizedEinExpr(EinExpr(path), size)
+
+head(sexpr::SizedEinExpr) = head(sexpr.path)
+args(sexpr::SizedEinExpr) = sexpr.path.args # map(Base.Fix2(SizedEinExpr, sexpr.size), sexpr.path.args)
+nargs(sexpr::SizedEinExpr) = nargs(sexpr.path)
+inds(sexpr::SizedEinExpr) = inds(sexpr.path)
+
+function Base.getproperty(sexpr::SizedEinExpr, name::Symbol)
+    name === :head && return getfield(sexpr, :path).head
+    name === :args && return getfield(sexpr, :path).args
+    return getfield(sexpr, name)
+end
+
+Base.:(==)(a::SizedEinExpr, b::SizedEinExpr) = a.path == b.path && a.size == b.size
+
+Base.ndims(sexpr::SizedEinExpr) = ndims(sexpr.path)
+
+Base.size(sexpr::SizedEinExpr) = size(sexpr.path, sexpr.size)
+Base.length(sexpr::SizedEinExpr) = length(sexpr.path, sexpr.size)
+
+collapse!(sexpr::SizedEinExpr) = collapse!(sexpr.path)
+
+select(sexpr::SizedEinExpr, i) = map(Base.Fix2(SizedEinExpr, sexpr.size), select(sexpr.path, i))
+
+neighbours(sexpr::SizedEinExpr, i) = map(Base.Fix2(SizedEinExpr, sexpr.size), neighbours(sexpr.path, i))
+
+contractorder(sexpr::SizedEinExpr) = contractorder(sexpr.path)
+
+hyperinds(sexpr::SizedEinExpr) = hyperinds(sexpr.path)
+
+suminds(sexpr::SizedEinExpr) = suminds(sexpr.path)
+parsuminds(sexpr::SizedEinExpr) = parsuminds(sexpr.path)
+
+Base.sum!(sexpr::SizedEinExpr, inds) = sum!(sexpr.path, inds)
+Base.sum(sexpr::SizedEinExpr, inds) = sum(sexpr.path, inds)
+
+function Base.sum(sexpr::Vector{SizedEinExpr}; skip = Symbol[])
+    path = sum(map(x -> x.path, sexpr); skip)
+    size = allequal(Iterators.map(x -> x.size, sexpr)) ? first(sexpr).size : merge(map(x -> x.size, sexpr)...)
+    # size = merge(map(x -> x.size, sexpr)...)
+    SizedEinExpr(path, size)
+end
+
+# Iteration interface
+Base.IteratorEltype(::Type{<:TreeIterator{SizedEinExpr}}) = Base.HasEltype()
+Base.eltype(::Type{<:TreeIterator{SizedEinExpr}}) = SizedEinExpr
+
+# AbstractTrees interface and traits
+AbstractTrees.children(sexpr::SizedEinExpr) = map(Base.Fix2(SizedEinExpr, sexpr.size), args(sexpr))
+AbstractTrees.childtype(::Type{SizedEinExpr}) = SizedEinExpr
+AbstractTrees.childrentype(::Type{SizedEinExpr}) = Vector{SizedEinExpr}
+AbstractTrees.childstatetype(::Type{SizedEinExpr}) = Int
+AbstractTrees.nodetype(::Type{SizedEinExpr}) = SizedEinExpr
+
+AbstractTrees.ParentLinks(::Type{SizedEinExpr}) = ImplicitParents()
+AbstractTrees.SiblingLinks(::Type{SizedEinExpr}) = ImplicitSiblings()
+AbstractTrees.ChildIndexing(::Type{SizedEinExpr}) = IndexedChildren()
+AbstractTrees.NodeType(::Type{SizedEinExpr}) = HasNodeType()

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -102,7 +102,7 @@ function findslices(
     candidates = Set(setdiff(mapreduce(head, ∪, PostOrderDFS(path)), skip))
     solution = Set{Symbol}()
     current = (; slices = 1, size = maximum(Base.Fix2(length, sizedict), PostOrderDFS(path)), overhead = 1.0)
-    original_flops = mapreduce(flops, +, Branches(path; inverse = true))
+    original_flops = mapreduce(Base.Fix2(flops, sizedict), +, Branches(path; inverse = true))
 
     sliced_path = path
     while !isempty(candidates)

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -102,7 +102,7 @@ function findslices(
     candidates = Set(setdiff(mapreduce(head, ∪, PostOrderDFS(path)), skip))
     solution = Set{Symbol}()
     current = (; slices = 1, size = maximum(Base.Fix2(length, sizedict), PostOrderDFS(path)), overhead = 1.0)
-    original_flops = mapreduce(Base.Fix2(flops, sizedict), +, Branches(path; inverse = true))
+    original_flops = mapreduce(flops(sizedict), +, Branches(path; inverse = true))
 
     sliced_path = path
     while !isempty(candidates)
@@ -115,7 +115,7 @@ function findslices(
         sliced_path = selectdim(sliced_path, winner, 1)
         cur_overhead =
             prod(i -> sizedict[i], [solution..., winner]) *
-            mapreduce(Base.Fix2(flops, sizedict), +, Branches(sliced_path; inverse = true)) / original_flops
+            mapreduce(flops(sizedict), +, Branches(sliced_path; inverse = true)) / original_flops
 
         !isnothing(overhead) && cur_overhead > overhead && break
         push!(solution, winner)

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -102,7 +102,7 @@ function findslices(
     candidates = Set(setdiff(mapreduce(head, ∪, PostOrderDFS(path)), skip))
     solution = Set{Symbol}()
     current = (; slices = 1, size = maximum(Base.Fix2(length, sizedict), PostOrderDFS(path)), overhead = 1.0)
-    original_flops = mapreduce(flops, +, Branches(path))
+    original_flops = mapreduce(flops, +, Branches(path; inverse = true))
 
     sliced_path = path
     while !isempty(candidates)
@@ -115,7 +115,7 @@ function findslices(
         sliced_path = selectdim(sliced_path, winner, 1)
         cur_overhead =
             prod(i -> sizedict[i], [solution..., winner]) *
-            mapreduce(Base.Fix2(flops, sizedict), +, Branches(sliced_path)) / original_flops
+            mapreduce(Base.Fix2(flops, sizedict), +, Branches(sliced_path; inverse = true)) / original_flops
 
         !isnothing(overhead) && cur_overhead > overhead && break
         push!(solution, winner)

--- a/test/Counters_test.jl
+++ b/test/Counters_test.jl
@@ -1,75 +1,77 @@
 @testset "Counters" begin
     using EinExprs: removedrank
 
-    @testset "identity" begin
-        tensor = EinExpr([:i, :j], Dict(:i => 2, :j => 3))
-        expr = EinExpr([:i, :j], [tensor])
+    sizedict = Dict(:i => 2, :j => 3, :k => 4, :l => 5)
 
-        @test flops(expr) == 0
-        @test removedsize(expr) == 0
-        @test removedrank(expr) == 0
+    @testset "identity" begin
+        tensor = EinExpr((:i, :j))
+        expr = EinExpr((:i, :j), [tensor])
+
+        @test flops(expr, sizedict) == 0
+        @test removedsize(expr, sizedict) == 0
+        @test removedrank(expr, sizedict) == 0
     end
 
     @testset "transpose" begin
-        tensor = EinExpr([:i, :j], Dict(:i => 2, :j => 3))
+        tensor = EinExpr((:i, :j))
         expr = EinExpr([:j, :i], [tensor])
 
-        @test flops(expr) == 0
-        @test removedsize(expr) == 0
-        @test removedrank(expr) == 0
+        @test flops(expr, sizedict) == 0
+        @test removedsize(expr, sizedict) == 0
+        @test removedrank(expr, sizedict) == 0
     end
 
     @testset "axis sum" begin
-        tensor = EinExpr([:i, :j], Dict(:i => 2, :j => 3))
-        expr = EinExpr([:i], [tensor])
+        tensor = EinExpr((:i, :j))
+        expr = EinExpr((:i,), [tensor])
 
-        @test flops(expr) == 6
-        @test removedsize(expr) == 4
-        @test removedrank(expr) == 1
+        @test flops(expr, sizedict) == 6
+        @test removedsize(expr, sizedict) == 4
+        @test removedrank(expr, sizedict) == 1
     end
 
     @testset "diagonal" begin
-        tensor = EinExpr([:i, :i], Dict(:i => 2))
-        expr = EinExpr([:i], [tensor])
+        tensor = EinExpr((:i, :i))
+        expr = EinExpr((:i,), [tensor])
 
-        @test flops(expr) == 0
-        @test removedsize(expr) == 2
-        @test removedrank(expr) == 1
+        @test flops(expr, sizedict) == 0
+        @test removedsize(expr, sizedict) == 2
+        @test removedrank(expr, sizedict) == 1
     end
 
     @testset "trace" begin
-        tensor = EinExpr([:i, :i], Dict(:i => 2))
+        tensor = EinExpr((:i, :i))
         expr = EinExpr(Symbol[], [tensor])
 
-        @test flops(expr) == 2
-        @test removedsize(expr) == 3
-        @test removedrank(expr) == 2
+        @test flops(expr, sizedict) == 2
+        @test removedsize(expr, sizedict) == 3
+        @test removedrank(expr, sizedict) == 2
     end
 
     @testset "outer product" begin
-        tensors = [EinExpr([:i, :j], Dict(:i => 2, :j => 3)), EinExpr([:k, :l], Dict(:k => 4, :l => 5))]
-        expr = EinExpr([:i, :j, :k, :l], tensors)
+        tensors = [EinExpr((:i, :j)), EinExpr((:k, :l))]
+        expr = EinExpr((:i, :j, :k, :l), tensors)
 
-        @test flops(expr) == prod(2:5)
-        @test removedsize(expr) == -94
-        @test removedrank(expr) == -2
+        @test flops(expr, sizedict) == prod(2:5)
+        @test removedsize(expr, sizedict) == -94
+        @test removedrank(expr, sizedict) == -2
     end
 
     @testset "inner product" begin
-        tensors = [EinExpr([:i], Dict(:i => 2)), EinExpr([:i], Dict(:i => 2))]
+        tensors = [EinExpr((:i,)), EinExpr((:i,))]
         expr = EinExpr(Symbol[], tensors)
 
-        @test flops(expr) == 2
-        @test removedsize(expr) == 3
-        @test removedrank(expr) == 1
+        @test flops(expr, sizedict) == 2
+        @test removedsize(expr, sizedict) == 3
+        @test removedrank(expr, sizedict) == 1
     end
 
     @testset "matrix multiplication" begin
-        tensors = [EinExpr([:i, :k], Dict(:i => 2, :k => 3)), EinExpr([:k, :j], Dict(:k => 3, :j => 4))]
-        expr = EinExpr([:i, :j], tensors)
+        tensors = [EinExpr((:i, :j)), EinExpr((:j, :k))]
+        expr = EinExpr((:i, :k), tensors)
 
-        @test flops(expr) == 2 * 3 * 4
-        @test removedsize(expr) == 10
-        @test removedrank(expr) == 0
+        @test flops(expr, sizedict) == 2 * 3 * 4
+        @test removedsize(expr, sizedict) == 10
+        @test removedrank(expr, sizedict) == 0
     end
 end

--- a/test/EinExpr_test.jl
+++ b/test/EinExpr_test.jl
@@ -2,7 +2,7 @@
     using LinearAlgebra
 
     @testset "identity" begin
-        tensor = EinExpr([:i, :j], Dict(:i => 2, :j => 3))
+        tensor = EinExpr([:i, :j])
         expr = EinExpr([:i, :j], [tensor])
 
         @test expr.head == head(tensor)
@@ -10,10 +10,6 @@
 
         @test head(expr) == head(tensor)
         @test ndims(expr) == 2
-
-        @test size(expr, :i) == 2
-        @test size(expr, :j) == 3
-        @test size(expr) == (2, 3)
 
         @test isempty(hyperinds(expr))
         @test isempty(suminds(expr))
@@ -27,7 +23,7 @@
     end
 
     @testset "transpose" begin
-        tensor = EinExpr([:i, :j], Dict(:i => 2, :j => 3))
+        tensor = EinExpr([:i, :j])
         expr = EinExpr([:j, :i], [tensor])
 
         @test expr.head == reverse(inds(tensor))
@@ -35,10 +31,6 @@
 
         @test head(expr) == reverse(inds(tensor))
         @test ndims(expr) == 2
-
-        @test size(expr, :i) == 2
-        @test size(expr, :j) == 3
-        @test size(expr) == (3, 2)
 
         @test isempty(hyperinds(expr))
         @test isempty(suminds(expr))
@@ -52,7 +44,7 @@
     end
 
     @testset "axis sum" begin
-        tensor = EinExpr([:i, :j], Dict(:i => 2, :j => 3))
+        tensor = EinExpr([:i, :j])
         expr = EinExpr((:i,), [tensor])
 
         @test all(splat(==), zip(expr.head, [:i]))
@@ -60,10 +52,6 @@
 
         @test all(splat(==), zip(head(expr), (:i,)))
         @test all(splat(==), zip(inds(expr), [:i, :j]))
-
-        @test size(expr, :i) == 2
-        @test size(expr, :j) == 3
-        @test size(expr) == (2,)
 
         @test isempty(hyperinds(expr))
         @test suminds(expr) == [:j]
@@ -77,7 +65,7 @@
     end
 
     @testset "diagonal" begin
-        tensor = EinExpr([:i, :i], Dict(:i => 2))
+        tensor = EinExpr([:i, :i])
         expr = EinExpr((:i,), [tensor])
 
         @test all(splat(==), zip(expr.head, (:i,)))
@@ -85,9 +73,6 @@
 
         @test all(splat(==), zip(head(expr), (:i,)))
         @test all(splat(==), zip(inds(expr), head(expr)))
-
-        @test size(expr, :i) == 2
-        @test size(expr) == (2,)
 
         @test isempty(hyperinds(expr))
         @test isempty(suminds(expr))
@@ -99,7 +84,7 @@
     end
 
     @testset "trace" begin
-        tensor = EinExpr([:i, :i], Dict(:i => 2))
+        tensor = EinExpr([:i, :i])
         expr = EinExpr(Symbol[], [tensor])
 
         @test isempty(expr.head)
@@ -107,9 +92,6 @@
 
         @test isempty(head(expr))
         @test all(splat(==), zip(inds(expr), (:i,)))
-
-        @test size(expr, :i) == 2
-        @test size(expr) == ()
 
         @test isempty(hyperinds(expr))
         @test suminds(expr) == [:i]
@@ -121,7 +103,7 @@
     end
 
     @testset "outer product" begin
-        tensors = [EinExpr([:i, :j], Dict(:i => 2, :j => 3)), EinExpr([:k, :l], Dict(:k => 4, :l => 5))]
+        tensors = [EinExpr([:i, :j]), EinExpr([:k, :l])]
         expr = EinExpr([:i, :j, :k, :l], tensors)
 
         @test all(splat(==), zip(expr.head, (:i, :j, :k, :l)))
@@ -130,11 +112,6 @@
         @test all(splat(==), zip(head(expr), mapreduce(collect ∘ inds, vcat, tensors)))
         @test all(splat(==), zip(inds(expr), head(expr)))
         @test ndims(expr) == 4
-
-        for (i, d) in zip([:i, :j, :k, :l], [2, 3, 4, 5])
-            @test size(expr, i) == d
-        end
-        @test size(expr) == (2, 3, 4, 5)
 
         @test isempty(hyperinds(expr))
         @test isempty(suminds(expr))
@@ -151,7 +128,7 @@
 
     @testset "inner product" begin
         @testset "Vector" begin
-            tensors = [EinExpr([:i], Dict(:i => 2)), EinExpr([:i], Dict(:i => 2))]
+            tensors = [EinExpr([:i]), EinExpr([:i])]
             expr = EinExpr(Symbol[], tensors)
 
             @test isempty(expr.head)
@@ -160,9 +137,6 @@
             @test isempty(head(expr))
             @test all(splat(==), zip(inds(expr), (:i,)))
             @test ndims(expr) == 0
-
-            @test size(expr, :i) == 2
-            @test size(expr) == ()
 
             @test isempty(hyperinds(expr))
             @test suminds(expr) == [:i]
@@ -173,7 +147,7 @@
             @test isempty(neighbours(expr, :i))
         end
         @testset "Matrix" begin
-            tensors = [EinExpr([:i, :j], Dict(:i => 2, :j => 3)), EinExpr([:i, :j], Dict(:i => 2, :j => 3))]
+            tensors = [EinExpr([:i, :j]), EinExpr([:i, :j])]
             expr = EinExpr(Symbol[], tensors)
 
             @test isempty(expr.head)
@@ -182,10 +156,6 @@
             @test isempty(head(expr))
             @test all(splat(==), zip(inds(expr), [:i, :j]))
             @test ndims(expr) == 0
-
-            @test size(expr, :i) == 2
-            @test size(expr, :j) == 3
-            @test size(expr) == ()
 
             @test isempty(hyperinds(expr))
             @test issetequal(suminds(expr), [:i, :j])
@@ -199,7 +169,7 @@
     end
 
     @testset "matrix multiplication" begin
-        tensors = [EinExpr([:i, :k], Dict(:i => 2, :k => 3)), EinExpr([:k, :j], Dict(:k => 3, :j => 4))]
+        tensors = [EinExpr([:i, :k]), EinExpr([:k, :j])]
         expr = EinExpr([:i, :j], tensors)
 
         @test all(splat(==), zip(expr.head, [:i, :j]))
@@ -208,11 +178,6 @@
         @test all(splat(==), zip(head(expr), [:i, :j]))
         @test all(splat(==), zip(inds(expr), (:i, :k, :j)))
         @test ndims(expr) == 2
-
-        @test size(expr, :i) == 2
-        @test size(expr, :j) == 4
-        @test size(expr, :k) == 3
-        @test size(expr) == (2, 4)
 
         @test isempty(hyperinds(expr))
         @test suminds(expr) == [:k]
@@ -228,20 +193,12 @@
 
     @testset "hyperindex contraction" begin
         @testset "hyperindex is not summed" begin
-            tensors = [
-                EinExpr([:i, :β, :j], Dict(i => 2 for i in [:i, :β, :j])),
-                EinExpr([:k, :β], Dict(i => 2 for i in [:k, :β])),
-                EinExpr([:β, :l, :m], Dict(i => 2 for i in [:β, :l, :m])),
-            ]
-
+            tensors = [EinExpr([:i, :β, :j]), EinExpr([:k, :β]), EinExpr([:β, :l, :m])]
             expr = sum(tensors, skip = [:β])
 
             @test issetequal(head(expr), (:i, :j, :k, :l, :m, :β))
             @test issetequal(inds(expr), (:i, :j, :k, :l, :m, :β))
             @test ndims(expr) == 6
-
-            @test all(i -> size(expr, i) == 2, inds(expr))
-            @test size(expr) == tuple(fill(2, 6)...)
 
             @test issetequal(hyperinds(expr), [:β])
             @test isempty(suminds(expr))
@@ -257,12 +214,7 @@
         end
 
         @testset "hyperindex is summed" begin
-            tensors = [
-                EinExpr([:i, :β, :j], Dict(i => 2 for i in [:i, :β, :j])),
-                EinExpr([:k, :β], Dict(i => 2 for i in [:k, :β])),
-                EinExpr([:β, :l, :m], Dict(i => 2 for i in [:β, :l, :m])),
-            ]
-
+            tensors = [EinExpr([:i, :β, :j]), EinExpr([:k, :β]), EinExpr([:β, :l, :m])]
             expr = sum(tensors)
 
             @test all(splat(==), zip(expr.head, (:i, :j, :k, :l, :m)))
@@ -271,9 +223,6 @@
             @test issetequal(head(expr), (:i, :j, :k, :l, :m))
             @test issetequal(inds(expr), (:i, :j, :k, :l, :m, :β))
             @test ndims(expr) == 5
-
-            @test all(i -> size(expr, i) == 2, inds(expr))
-            @test size(expr) == tuple(fill(2, 5)...)
 
             @test issetequal(hyperinds(expr), [:β])
             @test issetequal(suminds(expr), [:β])
@@ -291,13 +240,13 @@
 
     @testset "manual path" begin
         tensors = [
-            EinExpr([:j, :b, :i, :h], Dict(i => 2 for i in [:j, :b, :i, :h])),
-            EinExpr([:a, :c, :e, :f], Dict(i => 2 for i in [:a, :c, :e, :f])),
-            EinExpr([:j], Dict(i => 2 for i in [:j])),
-            EinExpr([:e, :a, :g], Dict(i => 2 for i in [:e, :a, :g])),
-            EinExpr([:f, :b], Dict(i => 2 for i in [:f, :b])),
-            EinExpr([:i, :h, :d], Dict(i => 2 for i in [:i, :h, :d])),
-            EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
+            EinExpr([:j, :b, :i, :h]),
+            EinExpr([:a, :c, :e, :f]),
+            EinExpr([:j]),
+            EinExpr([:e, :a, :g]),
+            EinExpr([:f, :b]),
+            EinExpr([:i, :h, :d]),
+            EinExpr([:d, :g, :c]),
         ]
 
         path = EinExpr(Symbol[], tensors)

--- a/test/Exhaustive_test.jl
+++ b/test/Exhaustive_test.jl
@@ -1,15 +1,16 @@
 @testset "Exhaustive" begin
+    sizedict = Dict(i => 2 for i in [:a, :b, :c, :d, :e, :f, :g, :h, :i, :j])
     tensors = [
-        EinExpr([:j, :b, :i, :h], Dict(i => 2 for i in [:j, :b, :i, :h])),
-        EinExpr([:a, :c, :e, :f], Dict(i => 2 for i in [:a, :c, :e, :f])),
-        EinExpr([:j], Dict(i => 2 for i in [:j])),
-        EinExpr([:e, :a, :g], Dict(i => 2 for i in [:e, :a, :g])),
-        EinExpr([:f, :b], Dict(i => 2 for i in [:f, :b])),
-        EinExpr([:i, :h, :d], Dict(i => 2 for i in [:i, :h, :d])),
-        EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
+        EinExpr([:j, :b, :i, :h]),
+        EinExpr([:a, :c, :e, :f]),
+        EinExpr([:j]),
+        EinExpr([:e, :a, :g]),
+        EinExpr([:f, :b]),
+        EinExpr([:i, :h, :d]),
+        EinExpr([:d, :g, :c]),
     ]
 
-    path = einexpr(Exhaustive, EinExpr(Symbol[], tensors))
+    path = einexpr(Exhaustive, EinExpr(Symbol[], tensors), sizedict)
 
     @test path isa EinExpr
 
@@ -18,14 +19,15 @@
     @test all(splat(issetequal), zip(contractorder(path), [[:a, :e], [:c, :g], [:f], [:d], [:b, :i, :h], [:j]]))
 
     @testset "hyperedges" begin
-        a = EinExpr([:i, :β, :j], Dict(i => 2 for i in [:i, :β, :j]))
-        b = EinExpr([:k, :β], Dict(i => 2 for i in [:k, :β]))
-        c = EinExpr([:β, :l, :m], Dict(i => 2 for i in [:β, :l, :m]))
+        sizedict = Dict(i => 2 for i in [:i, :j, :k, :l, :m, :β])
+        a = EinExpr([:i, :β, :j])
+        b = EinExpr([:k, :β])
+        c = EinExpr([:β, :l, :m])
 
-        path = einexpr(EinExprs.Exhaustive(), sum([a, b, c], skip = [:β]))
+        path = einexpr(EinExprs.Exhaustive(), sum([a, b, c], skip = [:β]), sizedict)
         @test all(∋(:β) ∘ head, branches(path))
 
-        path = einexpr(EinExprs.Exhaustive(), sum([a, b, c], skip = Symbol[]))
+        path = einexpr(EinExprs.Exhaustive(), sum([a, b, c], skip = Symbol[]), sizedict)
         @test all(∋(:β) ∘ head, branches(path)[1:end-1])
         @test all(!∋(:β) ∘ head, branches(path)[end:end])
     end

--- a/test/Exhaustive_test.jl
+++ b/test/Exhaustive_test.jl
@@ -9,14 +9,16 @@
         EinExpr([:i, :h, :d]),
         EinExpr([:d, :g, :c]),
     ]
+    expr = EinExpr(Symbol[], tensors)
+    sexpr = SizedEinExpr(expr, sizedict)
 
-    path = einexpr(Exhaustive, EinExpr(Symbol[], tensors), sizedict)
+    path = einexpr(Exhaustive, sexpr)
 
-    @test path isa EinExpr
+    @test path isa SizedEinExpr
 
-    @test mapreduce(flops, +, Branches(path)) == 90
+    @test mapreduce(flops, +, Branches(path)) == 92
 
-    @test all(splat(issetequal), zip(contractorder(path), [[:a, :e], [:c, :g], [:f], [:d], [:b, :i, :h], [:j]]))
+    @test all(splat(issetequal), zip(contractorder(path), [[:a, :e], [:c, :g], [:f], [:j], [:i, :h], [:d, :b]]))
 
     @testset "hyperedges" begin
         sizedict = Dict(i => 2 for i in [:i, :j, :k, :l, :m, :β])
@@ -24,10 +26,10 @@
         b = EinExpr([:k, :β])
         c = EinExpr([:β, :l, :m])
 
-        path = einexpr(EinExprs.Exhaustive(), sum([a, b, c], skip = [:β]), sizedict)
+        path = einexpr(EinExprs.Exhaustive(), SizedEinExpr(sum([a, b, c], skip = [:β]), sizedict))
         @test all(∋(:β) ∘ head, branches(path))
 
-        path = einexpr(EinExprs.Exhaustive(), sum([a, b, c], skip = Symbol[]), sizedict)
+        path = einexpr(EinExprs.Exhaustive(), SizedEinExpr(sum([a, b, c], skip = Symbol[]), sizedict))
         @test all(∋(:β) ∘ head, branches(path)[1:end-1])
         @test all(!∋(:β) ∘ head, branches(path)[end:end])
     end

--- a/test/Greedy_test.jl
+++ b/test/Greedy_test.jl
@@ -14,7 +14,7 @@
 
     @test path isa EinExpr
 
-    @test mapreduce(Base.Fix2(flops, sizedict), +, Branches(path)) == 100
+    @test mapreduce(flops(sizedict), +, Branches(path)) == 100
 
     @test all(splat(issetequal), zip(contractorder(path), [[:i, :h], [:j], [:a, :e], [:g, :c], [:f], [:b, :d]]))
 

--- a/test/Greedy_test.jl
+++ b/test/Greedy_test.jl
@@ -1,27 +1,26 @@
 @testset "Greedy" begin
+    sizedict = Dict(i => 2 for i in [:a, :b, :c, :d, :e, :f, :g, :h, :i, :j])
     tensors = [
-        EinExpr([:j, :b, :i, :h], Dict(i => 2 for i in [:j, :b, :i, :h])),
-        EinExpr([:a, :c, :e, :f], Dict(i => 2 for i in [:a, :c, :e, :f])),
-        EinExpr([:j], Dict(i => 2 for i in [:j])),
-        EinExpr([:e, :a, :g], Dict(i => 2 for i in [:e, :a, :g])),
-        EinExpr([:f, :b], Dict(i => 2 for i in [:f, :b])),
-        EinExpr([:i, :h, :d], Dict(i => 2 for i in [:i, :h, :d])),
-        EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
+        EinExpr([:j, :b, :i, :h]),
+        EinExpr([:a, :c, :e, :f]),
+        EinExpr([:j]),
+        EinExpr([:e, :a, :g]),
+        EinExpr([:f, :b]),
+        EinExpr([:i, :h, :d]),
+        EinExpr([:d, :g, :c]),
     ]
 
-    path = einexpr(Greedy(), EinExpr(Symbol[], tensors))
+    path = einexpr(Greedy(), EinExpr(Symbol[], tensors), sizedict)
 
     @test path isa EinExpr
 
-    @test mapreduce(flops, +, Branches(path)) == 100
+    @test mapreduce(Base.Fix2(flops, sizedict), +, Branches(path)) == 100
 
     @test all(splat(issetequal), zip(contractorder(path), [[:i, :h], [:j], [:a, :e], [:g, :c], [:f], [:b, :d]]))
 
     @testset "example: let unchanged" begin
-        tensors = [
-            EinExpr([:i, :j, :k], Dict(:i => 2, :j => 2, :k => 2)),
-            EinExpr([:k, :l, :m], Dict(:k => 2, :l => 2, :m => 2)),
-        ]
+        sizedict = Dict(i => 2 for i in [:i, :j, :k, :l, :m])
+        tensors = [EinExpr([:i, :j, :k]), EinExpr([:k, :l, :m])]
 
         path = einexpr(Greedy(), EinExpr(Symbol[:i, :j, :l, :m], tensors))
 
@@ -29,14 +28,15 @@
     end
 
     @testset "hyperedges" begin
-        a = EinExpr([:i, :β, :j], Dict(i => 2 for i in [:i, :β, :j]))
-        b = EinExpr([:k, :β], Dict(i => 2 for i in [:k, :β]))
-        c = EinExpr([:β, :l, :m], Dict(i => 2 for i in [:β, :l, :m]))
+        sizedict = Dict(i => 2 for i in [:i, :j, :k, :l, :m, :β])
+        a = EinExpr([:i, :β, :j])
+        b = EinExpr([:k, :β])
+        c = EinExpr([:β, :l, :m])
 
-        path = einexpr(EinExprs.Greedy(), sum([a, b, c], skip = [:β]))
+        path = einexpr(EinExprs.Greedy(), sum([a, b, c], skip = [:β]), sizedict)
         @test all(∋(:β) ∘ head, branches(path))
 
-        path = einexpr(EinExprs.Greedy(), sum([a, b, c], skip = Symbol[]))
+        path = einexpr(EinExprs.Greedy(), sum([a, b, c], skip = Symbol[]), sizedict)
         @test all(∋(:β) ∘ head, branches(path)[1:end-1])
         @test all(!∋(:β) ∘ head, branches(path)[end:end])
     end

--- a/test/KaHyPar_test.jl
+++ b/test/KaHyPar_test.jl
@@ -9,10 +9,11 @@
             EinExpr([:i, :h, :d], Dict(i => 2 for i in [:i, :h, :d])),
             EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
         ]
+        sexpr = sum(tensors)
 
-        path = einexpr(HyPar(imbalance=0.42), EinExpr(Symbol[], tensors))
+        path = einexpr(HyPar(imbalance = 0.42), sexpr)
 
-        @test path isa EinExpr
+        @test path isa SizedEinExpr
 
         @test mapreduce(flops, +, Branches(path)) == 108
     end
@@ -40,10 +41,11 @@
             EinExpr([:A, :W], Dict(:A => 6, :W => 6)),
             EinExpr([:a, :C, :d], Dict(:a => 3, :d => 6, :C => 4)),
         ]
+        sexpr = sum(tensors)
 
-        path = einexpr(HyPar(imbalance=0.45), EinExpr(Symbol[], tensors))
+        path = einexpr(HyPar(imbalance = 0.45), sexpr)
 
-        @test path isa EinExpr
+        @test path isa SizedEinExpr
 
         @test mapreduce(flops, +, Branches(path)) == 19099592
     end

--- a/test/Naive_test.jl
+++ b/test/Naive_test.jl
@@ -1,21 +1,22 @@
 @testset "Naive" begin
+    sizedict = Dict(i => 2 for i in [:a, :b, :c, :d, :e, :f, :g, :h, :i, :j])
     tensors = [
-        EinExpr([:j, :b, :i, :h], Dict(i => 2 for i in [:j, :b, :i, :h])),
-        EinExpr([:a, :c, :e, :f], Dict(i => 2 for i in [:a, :c, :e, :f])),
-        EinExpr([:j], Dict(i => 2 for i in [:j])),
-        EinExpr([:e, :a, :g], Dict(i => 2 for i in [:e, :a, :g])),
-        EinExpr([:f, :b], Dict(i => 2 for i in [:f, :b])),
-        EinExpr([:i, :h, :d], Dict(i => 2 for i in [:i, :h, :d])),
-        EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
+        EinExpr([:j, :b, :i, :h]),
+        EinExpr([:a, :c, :e, :f]),
+        EinExpr([:j]),
+        EinExpr([:e, :a, :g]),
+        EinExpr([:f, :b]),
+        EinExpr([:i, :h, :d]),
+        EinExpr([:d, :g, :c]),
     ]
 
-    path = einexpr(EinExprs.Naive(), EinExpr(Symbol[], tensors))
+    path = einexpr(EinExprs.Naive(), EinExpr(Symbol[], tensors), sizedict)
 
     @test path isa EinExpr
     @test foldl((a, b) -> sum([a, b]), tensors) == path
 
     # TODO traverse through the tree and check everything is ok
-    @test mapreduce(flops, +, Branches(path)) == 872
+    @test mapreduce(Base.Fix2(flops, sizedict), +, Branches(path)) == 872
 
     # FIXME non-determinist behaviour on order
     @test all(
@@ -24,14 +25,15 @@
     )
 
     @testset "hyperedges" begin
-        a = EinExpr([:i, :β, :j], Dict(i => 2 for i in [:i, :β, :j]))
-        b = EinExpr([:k, :β], Dict(i => 2 for i in [:k, :β]))
-        c = EinExpr([:β, :l, :m], Dict(i => 2 for i in [:β, :l, :m]))
+        sizedict = Dict(i => 2 for i in [:i, :j, :k, :l, :m, :β])
+        a = EinExpr([:i, :β, :j])
+        b = EinExpr([:k, :β])
+        c = EinExpr([:β, :l, :m])
 
-        path = einexpr(EinExprs.Naive(), sum([a, b, c], skip = [:β]))
+        path = einexpr(EinExprs.Naive(), sum([a, b, c], skip = [:β]), sizedict)
         @test all(∋(:β) ∘ head, branches(path))
 
-        path = einexpr(EinExprs.Naive(), sum([a, b, c], skip = Symbol[]))
+        path = einexpr(EinExprs.Naive(), sum([a, b, c], skip = Symbol[]), sizedict)
         @test all(∋(:β) ∘ head, branches(path)[1:end-1])
         @test all(!∋(:β) ∘ head, branches(path)[end:end])
     end

--- a/test/Naive_test.jl
+++ b/test/Naive_test.jl
@@ -16,7 +16,7 @@
     @test foldl((a, b) -> sum([a, b]), tensors) == path
 
     # TODO traverse through the tree and check everything is ok
-    @test mapreduce(Base.Fix2(flops, sizedict), +, Branches(path)) == 872
+    @test mapreduce(flops(sizedict), +, Branches(path)) == 872
 
     # FIXME non-determinist behaviour on order
     @test all(

--- a/test/SizedEinExpr_test.jl
+++ b/test/SizedEinExpr_test.jl
@@ -6,7 +6,8 @@
     sexpr = SizedEinExpr(expr, Dict(:i => 2, :j => 3))
 
     @test head(sexpr) === head(expr) === sexpr.head
-    @test args(sexpr) === args(expr) === sexpr.args
+    @test args(expr) === sexpr.args
+    @test args(sexpr) == map(Base.Fix2(SizedEinExpr, Dict(:i => 2, :j => 3)), args(expr))
     @test EinExprs.nargs(sexpr) == EinExprs.nargs(expr)
 
     @test inds(sexpr) == inds(expr)

--- a/test/SizedEinExpr_test.jl
+++ b/test/SizedEinExpr_test.jl
@@ -1,0 +1,22 @@
+@testset "SizedEinExpr" begin
+    using LinearAlgebra
+
+    tensor = EinExpr([:i, :j])
+    expr = EinExpr([:i, :j], [tensor])
+    sexpr = SizedEinExpr(expr, Dict(:i => 2, :j => 3))
+
+    @test head(sexpr) === head(expr) === sexpr.head
+    @test args(sexpr) === args(expr) === sexpr.args
+    @test EinExprs.nargs(sexpr) == EinExprs.nargs(expr)
+
+    @test inds(sexpr) == inds(expr)
+    @test ndims(sexpr) == ndims(expr)
+    @test length(sexpr) == 6
+
+    @test size(sexpr, :i) == 2
+    @test size(sexpr, :j) == 3
+    @test size(sexpr) == (2, 3)
+
+    @test select(sexpr, :i) == SizedEinExpr[sexpr, SizedEinExpr(tensor, Dict(:i => 2, :j => 3))]
+    @test select(sexpr, :j) == SizedEinExpr[sexpr, SizedEinExpr(tensor, Dict(:i => 2, :j => 3))]
+end

--- a/test/Slicing_test.jl
+++ b/test/Slicing_test.jl
@@ -42,49 +42,31 @@
                                                         [
                                                             EinExpr(
                                                                 [:m, :f, :g],
-                                                                [
-                                                                    EinExpr(
-                                                                        [:m, :f, :q],
-                                                                        Dict(i => sizes[i] for i in [:m, :f, :q]),
-                                                                    ),
-                                                                    EinExpr(
-                                                                        [:g, :q],
-                                                                        Dict(i => sizes[i] for i in [:g, :q]),
-                                                                    ),
-                                                                ],
+                                                                [EinExpr((:m, :f, :q),), EinExpr((:g, :q),)],
                                                             ),
-                                                            EinExpr(
-                                                                [:o, :i, :m, :c],
-                                                                Dict(i => sizes[i] for i in [:o, :i, :m, :c]),
-                                                            ),
+                                                            EinExpr((:o, :i, :m, :c),),
                                                         ],
                                                     ),
-                                                    EinExpr([:f, :l, :i], Dict(i => sizes[i] for i in [:f, :l, :i])),
+                                                    EinExpr((:f, :l, :i)),
                                                 ],
                                             ),
-                                            EinExpr([:g, :n, :l, :a], Dict(i => sizes[i] for i in [:g, :n, :l, :a])),
+                                            EinExpr((:g, :n, :l, :a)),
                                         ],
                                     ),
-                                    EinExpr(
-                                        [:e, :d, :o],
-                                        [
-                                            EinExpr([:b, :e], Dict(i => sizes[i] for i in [:b, :e])),
-                                            EinExpr([:d, :b, :o], Dict(i => sizes[i] for i in [:d, :b, :o])),
-                                        ],
-                                    ),
+                                    EinExpr([:e, :d, :o], [EinExpr((:b, :e)), EinExpr((:d, :b, :o))]),
                                 ],
                             ),
-                            EinExpr([:c, :e, :h], Dict(i => sizes[i] for i in [:c, :e, :h])),
+                            EinExpr((:c, :e, :h)),
                         ],
                     ),
-                    EinExpr([:k, :d, :h, :a, :n, :j], Dict(i => sizes[i] for i in [:k, :d, :h, :a, :n, :j])),
+                    EinExpr((:k, :d, :h, :a, :n, :j)),
                 ],
             ),
-            EinExpr([:p, :k], Dict(i => sizes[i] for i in [:p, :k])),
+            EinExpr((:p, :k)),
         ],
     )
 
     cuttings = findslices(FlopsScorer(), expr, slices = 1000)
 
-    @test prod(i -> size(expr, i), cuttings) >= 1000
+    @test prod(i -> sizedict[i], cuttings) >= 1000
 end

--- a/test/Slicing_test.jl
+++ b/test/Slicing_test.jl
@@ -65,8 +65,9 @@
             EinExpr((:p, :k)),
         ],
     )
+    sexpr = SizedEinExpr(expr, sizes)
 
-    cuttings = findslices(FlopsScorer(), expr, slices = 1000)
+    cuttings = findslices(FlopsScorer(), sexpr, slices = 1000)
 
-    @test prod(i -> sizedict[i], cuttings) >= 1000
+    @test prod(i -> sizes[i], cuttings) >= 1000
 end

--- a/test/ext/Makie_test.jl
+++ b/test/ext/Makie_test.jl
@@ -34,8 +34,8 @@
         EinExpr([:g, :q], filter(p -> p.first ∈ [:g, :q], sizes)),
         EinExpr([:d, :b, :o], filter(p -> p.first ∈ [:d, :b, :o], sizes)),
     ]
-
-    path = einexpr(Exhaustive(), EinExpr([:p, :j], tensors))
+    expr = sum(tensors, skip = [:p, :j])
+    path = einexpr(Exhaustive(), expr)
 
     @testset "plot!" begin
         f = Figure()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using EinExprs
 
 @testset "Unit tests" verbose = true begin
     include("EinExpr_test.jl")
+    include("SizedEinExpr_test.jl")
     include("Counters_test.jl")
     @testset "Optimizers" begin
         include("Naive_test.jl")


### PR DESCRIPTION
When manipulating `EinExpr`s (e.g. creating, summing, ...), creation and merge of `size` dictionaries incurs into a large amount of allocations.

This PR decouples `size` dictionary from `EinExpr` and introduces `SizedEinExpr`: a `EinExpr` wrapper with a global index size dictionary.

```julia

julia> using EinExprs, BenchmarkTools

expr = sum([
    EinExpr([:j, :b, :i, :h], Dict(i => 2 for i in [:j, :b, :i, :h])),
    EinExpr([:a, :c, :e, :f], Dict(i => 2 for i in [:a, :c, :e, :f])),
    EinExpr([:j], Dict(i => 2 for i in [:j])),
    EinExpr([:e, :a, :g], Dict(i => 2 for i in [:e, :a, :g])),
    EinExpr([:f, :b], Dict(i => 2 for i in [:f, :b])),
    EinExpr([:i, :h, :d], Dict(i => 2 for i in [:i, :h, :d])),
    EinExpr([:d, :g, :c], Dict(i => 2 for i in [:d, :g, :c])),
])

@benchmark path = einexpr(Exhaustive(), expr)
```

### Before
```julia
BenchmarkTools.Trial: 2442 samples with 1 evaluation.
 Range (min … max):  1.618 ms … 7.713 ms  ┊ GC (min … max):  0.00% … 42.34%
 Time  (median):     1.674 ms             ┊ GC (median):     0.00%
 Time  (mean ± σ):   2.046 ms ± 1.072 ms  ┊ GC (mean ± σ):  13.91% ± 16.30%

  █▆▂                                               ▁▁▁▁▁    
  ████▇▆▄▃▄▁▁▁▁▁▃▃▁▃▁▁▁▁▁▁▃▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▇██████▇ █
  1.62 ms     Histogram: log(frequency) by time     5.37 ms <

 Memory estimate: 4.51 MiB, allocs estimate: 65772.
```

### After
```julia
BenchmarkTools.Trial: 9124 samples with 1 evaluation.
 Range (min … max):  400.167 μs …  14.535 ms  ┊ GC (min … max):  0.00% … 66.90%
 Time  (median):     425.625 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   546.911 μs ± 966.583 μs  ┊ GC (mean ± σ):  11.38% ±  6.06%

  █▂                                                            ▁
  ██▆▅▄▄▃▁▃▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▃▇▆ █
  400 μs        Histogram: log(frequency) by time       8.27 ms <

 Memory estimate: 621.73 KiB, allocs estimate: 11344.
```