### PR TITLE
Enhance performance of ` FlopsScorer` for `findslices`

### DIFF
--- a/src/Counters.jl
+++ b/src/Counters.jl
@@ -41,6 +41,34 @@ end
 
 fastflops(expr::EinExpr, size) = fastflops(SizedEinExpr(expr, size))
 
+# Function wrapper to compute the flops of a path, excluding a given index
+function filtered_flops(sexpr::SizedEinExpr, index)
+    if nargs(sexpr) == 0 || nargs(sexpr) == 1 && isempty(suminds(sexpr))
+        0
+    else
+        ret = one(BigInt)
+        for element in Iterators.flatten((head(sexpr), suminds(sexpr)))
+            if element != index
+                ret *= getindex(sexpr.size, element)
+            end
+        end
+        ret
+    end
+end
+
+# Function wrapper to compute the flops of a path, excluding a given index
+function filtered_length(sexpr::SizedEinExpr, index)
+    path = sexpr.path
+    sizedict = sexpr.size
+
+    # remove index from the head
+    if index ∈ head(path)
+        path = selectdim(path, index, 1)
+    end
+
+    return (prod ∘ size)(path, sizedict)
+end
+
 """
     removedsize(path::EinExpr)
 

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -151,23 +151,11 @@ function (cb::FlopsScorer)(path, index)
             flops(sexpr) - filtered_flops(sexpr, index),
             length(sexpr) - filtered_length(sexpr, index)
         ),
-        (a, b) -> (a[1] + b[1], a[2] + b[2]),
+        .+,
         PostOrderDFS(path))
 
     flops_reduction, write_reduction = total_reductions
     return log(flops_reduction + write_reduction * cb.weight + 1)
-end
-
-function (cb::FlopsScorer)(path, index)
-    flops_reduction = BigInt(0)
-    write_reduction = BigInt(0)
-
-    @inbounds for sexpr in PostOrderDFS(path)
-        flops_reduction += flops(sexpr) - filtered_flops(sexpr, index)
-        write_reduction += length(sexpr) - filtered_length(sexpr, index)
-    end
-
-    log(flops_reduction + write_reduction * cb.weight + 1)
 end
 
 """

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -146,10 +146,13 @@ Base.@kwdef struct FlopsScorer <: Scorer
 end
 
 function (cb::FlopsScorer)(path, index)
-    slice = selectdim(path, index, 1)
+    flops_reduction = 0.
+    write_reduction = 0.
 
-    flops_reduction = mapreduce(flops, +, PostOrderDFS(path)) - mapreduce(flops, +, PostOrderDFS(slice))
-    write_reduction = mapreduce(length, +, PostOrderDFS(path)) - mapreduce(length, +, PostOrderDFS(slice))
+    for sexpr in PostOrderDFS(path)
+        flops_reduction += flops(sexpr) - filtered_flops(sexpr, index)
+        write_reduction += length(sexpr) - filtered_length(sexpr, index)
+    end
 
     log(flops_reduction + write_reduction * cb.weight + 1)
 end

--- a/src/Slicing.jl
+++ b/src/Slicing.jl
@@ -146,10 +146,23 @@ Base.@kwdef struct FlopsScorer <: Scorer
 end
 
 function (cb::FlopsScorer)(path, index)
-    flops_reduction = 0.
-    write_reduction = 0.
+    total_reductions = mapreduce(
+        sexpr -> (
+            flops(sexpr) - filtered_flops(sexpr, index),
+            length(sexpr) - filtered_length(sexpr, index)
+        ),
+        (a, b) -> (a[1] + b[1], a[2] + b[2]),
+        PostOrderDFS(path))
 
-    for sexpr in PostOrderDFS(path)
+    flops_reduction, write_reduction = total_reductions
+    return log(flops_reduction + write_reduction * cb.weight + 1)
+end
+
+function (cb::FlopsScorer)(path, index)
+    flops_reduction = BigInt(0)
+    write_reduction = BigInt(0)
+
+    @inbounds for sexpr in PostOrderDFS(path)
         flops_reduction += flops(sexpr) - filtered_flops(sexpr, index)
         write_reduction += length(sexpr) - filtered_length(sexpr, index)
     end


### PR DESCRIPTION
### Summary
This PR addresses the performance issues of the `FlopsScorer`, a scorer used by the `findslices` function. Before this PR, this function was not very efficient since it created a lot of `PostOrderDFS` instances, and that was slow. 
In this PR, we modify the `FlopsScorer` so now it directly calculates the difference in score resulting from the slice, rather than creating some copies of the contraction path. This implementation is more efficient (it can reduce the runtime about ~50%) and I have checked that it yields to the same results as before. 

### Example
See this performance gain:
```julia
julia> using Tenet; using EinExprs; using BenchmarkTools

julia> tn = rand(TensorNetwork, 200, 3)
TensorNetwork (#tensors=200, #inds=300)

julia> path = einexpr(
           tn,
           optimizer = EinExprs.Greedy,
       )
Symbol[] 1 flops, 1 elems
├─ Symbol[] 3 flops, 1 elems
...

julia> max_dims_path = maximum(ndims, Branches(path))
55

julia> t_size= 2^27
134217728

julia> @btime setnew = findslices(EinExprs.FlopsScorer(), path, size = t_size, temperature=0.) # OLD implementation
  16.420 s (362734668 allocations: 11.88 GiB)
Set{Symbol} with 48 elements:
  :ź
  :ƭ
  :ũ
  :ŉ
  ⋮ 

julia> @btime setold = findslices(EinExprs.FlopsScorerOld(), path, size = t_size, temperature=0.) # NEW implementation
  31.575 s (568955147 allocations: 20.08 GiB)
Set{Symbol} with 48 elements:
  :ź
  :ƭ
  :ũ
  :ŉ
  ⋮
```

As you can see, we reduced by 50% the runtime and almost 50% the memory allocations too.