### PR TITLE
Fix stack overflow error on `indshistogram`

### DIFF
--- a/src/EinExpr.jl
+++ b/src/EinExpr.jl
@@ -197,7 +197,19 @@ parsuminds(path::EinExpr) =
 indshistogram(exprs...) = mergewith(+, map(exprs) do expr
     Dict(i => 1 for i in head(expr))
 end...)
-indshistogram(exprs::Vector) = indshistogram(exprs...)
+
+#indshistogram(exprs::Vector) = indshistogram(exprs...)
+
+function indshistogram(exprs::Vector{EinExpr{L}}) where {L}
+    histogram = Dict{L, Int}()
+
+    for expr in exprs, i in head(expr)
+        count = get!(histogram, i, 0)
+        histogram[i] = count + 1
+    end
+
+    return histogram
+end
 
 """
     sum!(path, indices)

--- a/src/Optimizers/Greedy.jl
+++ b/src/Optimizers/Greedy.jl
@@ -32,7 +32,7 @@ function einexpr(config::Greedy, path::EinExpr{L}, sizedict::Dict{L}) where {L}
     path = sumtraces(path)
     metric = config.metric(sizedict)
 
-    hyperhistogram = filter!(indshistogram(args(path)...)) do (_, v)
+    hyperhistogram = filter!(indshistogram(args(path))) do (_, v)
         v > 2
     end
 


### PR DESCRIPTION
The function `indshistogram` errors on large inputs. This PR fixes the problem.