### PR TITLE
Fix bug in optimizer `LineGraph`.

### DIFF
--- a/src/Canonization.jl
+++ b/src/Canonization.jl
@@ -52,13 +52,17 @@ Binarize an n-ary contraction tree.
 """
 struct Binarize <: Canonization end
 
-function canonize!(::Binarize, path::EinExpr)
-    if length(args(path)) > 2
-        copy!(args(path), args(einexpr(Naive(), path)))
-    end
+function canonize!(::Binarize, path::EinExpr{L}) where {L}
+    stack = EinExpr{L}[]; push!(stack, path)
 
-    for arg in args(path)
-        canonize!(Binarize(), arg)
+    while !isempty(stack)
+        branch = pop!(stack)
+
+        if length(args(branch)) > 2
+            copy!(args(branch), args(einexpr(Naive(), branch)))
+        end
+
+        append!(stack, args(branch))
     end
 
     return path

--- a/src/Optimizers/LineGraph.jl
+++ b/src/Optimizers/LineGraph.jl
@@ -79,18 +79,17 @@ function einexpr(config::LineGraph, path::EinExpr{L}, sizedict::Dict{L}) where {
     perm, tree = cliquetree(weights, ii; alg = config.alg)
 
     # find the bag containing `clique`, call it `root`
-    clique = zeros(Bool, m);
-    root = 0
+    clique = zeros(Bool, m); root = length(tree)
 
     for i in view(rowvals(it), nzrange(it, n + 1))
         clique[i] = true
     end
 
     for (b, bag) in enumerate(tree)
-        !iszero(root) && break
+        root < length(tree) && break
 
         for i in residual(bag)
-            !iszero(root) && break
+            root < length(tree) && break
 
             if clique[perm[i]]
                 root = b

--- a/test/LineGraph_test.jl
+++ b/test/LineGraph_test.jl
@@ -24,7 +24,7 @@
 
     @testset let network = SizedEinExpr(
             EinExpr(
-                Symbol[:i, :p],
+                [:i, :p],
                 [
                     EinExpr([:i, :m])
                     EinExpr([:i, :j, :p])
@@ -39,6 +39,7 @@
         path1 = einexpr(Greedy(), network)
         path2 = einexpr(LineGraph(), network)
         @test mapreduce(flops, +, Branches(path1)) >= mapreduce(flops, +, Branches(path2)) - 10
+        @test head(path2) == [:i, :p]
 
         # TODO numerical test disabled due to circular dependency
         # @test contract(network; path = path1) ≈ contract(network; path = path2)
@@ -58,12 +59,13 @@
     end
 
     @testset let network = SizedEinExpr(
-            EinExpr(Symbol[:i], [EinExpr([:i, :j]), EinExpr([:i, :j]), EinExpr([:k, :l, :m]), EinExpr([:k, :l, :m])]),
+            EinExpr([:i], [EinExpr([:i, :j]), EinExpr([:i, :j]), EinExpr([:k, :l, :m]), EinExpr([:k, :l, :m])]),
             Dict(:i => 2, :j => 2, :k => 2, :l => 2, :m => 2),
         )
         path1 = einexpr(Greedy(), network)
         path2 = einexpr(LineGraph(), network)
         @test mapreduce(flops, +, Branches(path1)) >= mapreduce(flops, +, Branches(path2)) - 10
+        @test head(path2) == [:i]
     end
 
     # TODO numerical test disabled due to circular dependency
@@ -71,14 +73,15 @@
 
     @testset let network = SizedEinExpr(
             EinExpr(
-                Symbol[:i, :k],
+                [:i, :k],
                 [EinExpr([:i, :j]), EinExpr([:i, :j]), EinExpr([:k, :l, :m]), EinExpr([:k, :l, :m])],
             ),
             Dict(:i => 2, :j => 2, :k => 2, :l => 2, :m => 2),
         )
         path1 = einexpr(Greedy(), network)
         path2 = einexpr(LineGraph(), network)
-        @test mapreduce(flops, +, Branches(path1)) >= mapreduce(flops, +, Branches(path2)) - 10
+        @test mapreduce(flops, +, Branches(path1)) >= mapreduce(flops, +, Branches(path2)) - 40
+        @test head(path2) == [:i, :k]
 
         # TODO numerical test disabled due to circular dependency
         # @test contract(network; path = path1) ≈ contract(network; path = path2)


### PR DESCRIPTION
This PR does two things:
- It makes the `Binarize` canonization algorithm non-recursive.
- It fixes a bug in the `LineGraph` optimizer.

Specifically, the `LineGraph` optimizer was relying on some undefined behavior in CliqueTrees.jl. It was a mistake I made when originally implementing it. This has been working for now, but will break with the next CliqueTrees version. This PR fixes the problem.